### PR TITLE
chore: add Dependabot config for npm dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore"
+      prefix-development: "chore"
+      include: "scope"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react*"


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` for automated npm dependency updates
- Weekly schedule (Mondays), minor and major bumps only — patches ignored
- PRs grouped by dev dependencies and React packages to reduce noise
- Conventional commit prefixes on PR titles (`chore(deps):` / `chore(deps-dev):`)

## Test plan
- [ ] Verify Dependabot is enabled in repo Settings > Security > Code security
- [ ] Confirm first scheduled PRs follow `chore(deps):` naming

🤖 Generated with [Claude Code](https://claude.com/claude-code)