### PR TITLE
chore: add markdown files to prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,4 @@ coverage
 public/fonts
 .github
 .claude
+*.md


### PR DESCRIPTION
Add `*.md` to `.prettierignore` to exclude markdown files from Prettier formatting.

Related to #8

Generated with [Claude Code](https://claude.ai/code)