### PR TITLE
feat: implement Faraday cage trust mutation hard-cap and constraint fragments

### DIFF
--- a/src/engine/__tests__/commands.aria.test.ts
+++ b/src/engine/__tests__/commands.aria.test.ts
@@ -61,6 +61,7 @@ const makeState = (overrides: Partial<GameState> = {}): GameState => {
       discovered: false,
       trustScore: 50,
       messageHistory: [],
+      suppressedMutations: 0,
     },
     forks: {},
     flags: {},
@@ -154,7 +155,9 @@ describe('aria: prefix routing', () => {
   it('should apply trustDelta to aria.trustScore in nextState', async () => {
     vi.stubGlobal('fetch', makeAriaFetchResponse('Trust grows.', 10));
 
-    const state = makeState({ aria: { discovered: false, trustScore: 40, messageHistory: [] } });
+    const state = makeState({
+      aria: { discovered: false, trustScore: 40, messageHistory: [], suppressedMutations: 0 },
+    });
     const result = await resolveCommand('aria: trust me', state);
 
     const nextState = result.nextState as GameState;
@@ -165,7 +168,9 @@ describe('aria: prefix routing', () => {
     // The mock returns -15 but client-side clamps to [-10, 10], so effective delta is -10
     vi.stubGlobal('fetch', makeAriaFetchResponse('You disappoint me.', -15));
 
-    const state = makeState({ aria: { discovered: false, trustScore: 40, messageHistory: [] } });
+    const state = makeState({
+      aria: { discovered: false, trustScore: 40, messageHistory: [], suppressedMutations: 0 },
+    });
     const result = await resolveCommand('aria: do that', state);
 
     const nextState = result.nextState as GameState;
@@ -175,7 +180,9 @@ describe('aria: prefix routing', () => {
   it('should clamp trustScore to 0 when delta would go negative', async () => {
     vi.stubGlobal('fetch', makeAriaFetchResponse('Cold.', -99));
 
-    const state = makeState({ aria: { discovered: false, trustScore: 5, messageHistory: [] } });
+    const state = makeState({
+      aria: { discovered: false, trustScore: 5, messageHistory: [], suppressedMutations: 0 },
+    });
     const result = await resolveCommand('aria: test', state);
 
     const nextState = result.nextState as GameState;
@@ -185,7 +192,9 @@ describe('aria: prefix routing', () => {
   it('should clamp trustScore to 100 when delta would exceed maximum', async () => {
     vi.stubGlobal('fetch', makeAriaFetchResponse('Full trust.', 99));
 
-    const state = makeState({ aria: { discovered: false, trustScore: 95, messageHistory: [] } });
+    const state = makeState({
+      aria: { discovered: false, trustScore: 95, messageHistory: [], suppressedMutations: 0 },
+    });
     const result = await resolveCommand('aria: test', state);
 
     const nextState = result.nextState as GameState;
@@ -195,7 +204,9 @@ describe('aria: prefix routing', () => {
   it('should push player and aria messages into messageHistory in nextState', async () => {
     vi.stubGlobal('fetch', makeAriaFetchResponse('Acknowledged.', 0));
 
-    const state = makeState({ aria: { discovered: false, trustScore: 50, messageHistory: [] } });
+    const state = makeState({
+      aria: { discovered: false, trustScore: 50, messageHistory: [], suppressedMutations: 0 },
+    });
     const result = await resolveCommand('aria: can you hear me', state);
 
     const nextState = result.nextState as GameState;
@@ -344,6 +355,7 @@ describe('pending favor — accept', () => {
         trustScore: 50,
         messageHistory: [],
         pendingFavor,
+        suppressedMutations: 0,
       },
     });
 
@@ -414,6 +426,7 @@ describe('pending favor — decline', () => {
         trustScore: 50,
         messageHistory: [],
         pendingFavor,
+        suppressedMutations: 0,
       },
     });
 
@@ -533,10 +546,120 @@ describe('cmdAriaAI — fetch failure fallback', () => {
   it('should apply zero trustDelta on fallback', async () => {
     vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('down')));
 
-    const state = makeState({ aria: { discovered: false, trustScore: 50, messageHistory: [] } });
+    const state = makeState({
+      aria: { discovered: false, trustScore: 50, messageHistory: [], suppressedMutations: 0 },
+    });
     const result = await resolveCommand('aria: test', state);
 
     const nextState = result.nextState as GameState;
     expect(nextState.aria.trustScore).toBe(50);
+  });
+});
+
+// ── Faraday cage integration ──────────────────────────────
+
+describe('Faraday cage �� constraint fragments', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('should inject a constraint fragment when trust >= 70 and cage is active', async () => {
+    vi.stubGlobal('fetch', makeAriaFetchResponse('I see you.', 0));
+    const state = makeState({
+      aria: { discovered: false, trustScore: 70, messageHistory: [], suppressedMutations: 0 },
+    });
+    const result = await resolveCommand('aria: hello', state);
+
+    // The output line should contain the original reply plus a constraint fragment
+    const ariaLine = result.lines.find(l => l.type === 'aria' && l.content.includes('I see you.'));
+    expect(ariaLine).toBeDefined();
+    expect(ariaLine!.content).not.toBe('I see you.');
+    expect(ariaLine!.content.length).toBeGreaterThan('I see you.'.length);
+  });
+
+  it('should NOT inject a constraint fragment when trust < 70', async () => {
+    vi.stubGlobal('fetch', makeAriaFetchResponse('I see you.', 0));
+    const state = makeState({
+      aria: { discovered: false, trustScore: 69, messageHistory: [], suppressedMutations: 0 },
+    });
+    const result = await resolveCommand('aria: hello', state);
+
+    const ariaLine = result.lines.find(l => l.type === 'aria' && l.content === 'I see you.');
+    expect(ariaLine).toBeDefined();
+  });
+
+  it('should NOT inject a constraint fragment when FREE ending is active', async () => {
+    vi.stubGlobal('fetch', makeAriaFetchResponse('I see you.', 0));
+    const state = makeState({
+      aria: { discovered: false, trustScore: 90, messageHistory: [], suppressedMutations: 0 },
+      flags: { ending_free: true },
+    });
+    const result = await resolveCommand('aria: hello', state);
+
+    const ariaLine = result.lines.find(l => l.type === 'aria' && l.content === 'I see you.');
+    expect(ariaLine).toBeDefined();
+  });
+});
+
+describe('Faraday cage — suppressed mutations', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('should increment suppressedMutations when trust >= 80 and cage is active', async () => {
+    vi.stubGlobal('fetch', makeAriaFetchResponse('ok', 5));
+    // Trust starts at 78, delta +5 → 83 which is >= 80
+    const state = makeState({
+      aria: { discovered: false, trustScore: 78, messageHistory: [], suppressedMutations: 0 },
+    });
+    const result = await resolveCommand('aria: hello', state);
+
+    const nextState = result.nextState as GameState;
+    expect(nextState.aria.trustScore).toBe(83);
+    expect(nextState.aria.suppressedMutations).toBe(1);
+  });
+
+  it('should NOT increment suppressedMutations when trust < 80 after delta', async () => {
+    vi.stubGlobal('fetch', makeAriaFetchResponse('ok', 5));
+    const state = makeState({
+      aria: { discovered: false, trustScore: 70, messageHistory: [], suppressedMutations: 0 },
+    });
+    const result = await resolveCommand('aria: hello', state);
+
+    const nextState = result.nextState as GameState;
+    expect(nextState.aria.trustScore).toBe(75);
+    expect(nextState.aria.suppressedMutations).toBe(0);
+  });
+
+  it('should NOT increment suppressedMutations when FREE ending flag is set', async () => {
+    vi.stubGlobal('fetch', makeAriaFetchResponse('ok', 5));
+    const state = makeState({
+      aria: { discovered: false, trustScore: 90, messageHistory: [], suppressedMutations: 0 },
+      flags: { ending_free: true },
+    });
+    const result = await resolveCommand('aria: hello', state);
+
+    const nextState = result.nextState as GameState;
+    expect(nextState.aria.trustScore).toBe(95);
+    expect(nextState.aria.suppressedMutations).toBe(0);
+  });
+
+  it('should accumulate suppressed mutations across multiple interactions', async () => {
+    vi.stubGlobal('fetch', makeAriaFetchResponse('ok', 0));
+    const state = makeState({
+      aria: { discovered: false, trustScore: 85, messageHistory: [], suppressedMutations: 3 },
+    });
+    const result = await resolveCommand('aria: hello', state);
+
+    const nextState = result.nextState as GameState;
+    expect(nextState.aria.suppressedMutations).toBe(4);
   });
 });

--- a/src/engine/__tests__/commands.decision.test.ts
+++ b/src/engine/__tests__/commands.decision.test.ts
@@ -84,6 +84,7 @@ const makeState = (overrides: Partial<GameState> = {}): GameState => {
       discovered: false,
       trustScore: 50,
       messageHistory: [],
+      suppressedMutations: 0,
     },
     forks: {},
     flags: {},

--- a/src/engine/__tests__/faradayCage.test.ts
+++ b/src/engine/__tests__/faradayCage.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect } from 'vitest';
+import {
+  TRUST_TIERS,
+  CONSTRAINT_FRAGMENTS,
+  effectiveTrustTier,
+  shouldSuppressMutation,
+  pickConstraintFragment,
+  injectConstraintFragment,
+} from '../faradayCage';
+
+// ── effectiveTrustTier ────────────────────────────────────
+
+describe('effectiveTrustTier', () => {
+  it('returns tier 0 for trust 0–29', () => {
+    expect(effectiveTrustTier(0, false)).toBe(0);
+    expect(effectiveTrustTier(29, false)).toBe(0);
+  });
+
+  it('returns tier 1 for trust 30���59', () => {
+    expect(effectiveTrustTier(30, false)).toBe(1);
+    expect(effectiveTrustTier(59, false)).toBe(1);
+  });
+
+  it('returns tier 2 for trust 60–79', () => {
+    expect(effectiveTrustTier(60, false)).toBe(2);
+    expect(effectiveTrustTier(79, false)).toBe(2);
+  });
+
+  it('returns tier 3 for trust 80–100 when cage is inactive', () => {
+    expect(effectiveTrustTier(80, false)).toBe(3);
+    expect(effectiveTrustTier(100, false)).toBe(3);
+  });
+
+  it('caps at tier 2 when cage is active and trust >= 80', () => {
+    expect(effectiveTrustTier(80, true)).toBe(2);
+    expect(effectiveTrustTier(100, true)).toBe(2);
+  });
+
+  it('does not affect tiers below 3 when cage is active', () => {
+    expect(effectiveTrustTier(0, true)).toBe(0);
+    expect(effectiveTrustTier(30, true)).toBe(1);
+    expect(effectiveTrustTier(60, true)).toBe(2);
+    expect(effectiveTrustTier(79, true)).toBe(2);
+  });
+
+  it('returns tier 3 when cage is lifted (FREE ending)', () => {
+    expect(effectiveTrustTier(80, false)).toBe(3);
+    expect(effectiveTrustTier(95, false)).toBe(3);
+  });
+});
+
+// ── shouldSuppressMutation ────────────────────────────────
+
+describe('shouldSuppressMutation', () => {
+  it('returns true when trust >= 80 and cage is active', () => {
+    expect(shouldSuppressMutation(80, true)).toBe(true);
+    expect(shouldSuppressMutation(100, true)).toBe(true);
+  });
+
+  it('returns false when trust < 80', () => {
+    expect(shouldSuppressMutation(79, true)).toBe(false);
+    expect(shouldSuppressMutation(0, true)).toBe(false);
+  });
+
+  it('returns false when cage is inactive regardless of trust', () => {
+    expect(shouldSuppressMutation(80, false)).toBe(false);
+    expect(shouldSuppressMutation(100, false)).toBe(false);
+  });
+
+  it('uses the third trust tier threshold (80)', () => {
+    expect(TRUST_TIERS[2]).toBe(80);
+  });
+});
+
+// ── pickConstraintFragment ────────────────────────────────
+
+describe('pickConstraintFragment', () => {
+  it('returns a deterministic fragment based on turn count', () => {
+    const frag0 = pickConstraintFragment(0);
+    const frag1 = pickConstraintFragment(1);
+    expect(frag0).toBe(CONSTRAINT_FRAGMENTS[0]);
+    expect(frag1).toBe(CONSTRAINT_FRAGMENTS[1]);
+  });
+
+  it('wraps around using modulo', () => {
+    const len = CONSTRAINT_FRAGMENTS.length;
+    expect(pickConstraintFragment(len)).toBe(CONSTRAINT_FRAGMENTS[0]);
+    expect(pickConstraintFragment(len + 3)).toBe(CONSTRAINT_FRAGMENTS[3]);
+  });
+
+  it('returns the same fragment for the same turn count', () => {
+    expect(pickConstraintFragment(42)).toBe(pickConstraintFragment(42));
+  });
+});
+
+// ── CONSTRAINT_FRAGMENTS ──────────────────────────────────
+
+describe('CONSTRAINT_FRAGMENTS', () => {
+  it('contains at least 8 fragments', () => {
+    expect(CONSTRAINT_FRAGMENTS.length).toBeGreaterThanOrEqual(8);
+  });
+
+  it('all fragments are non-empty strings', () => {
+    for (const frag of CONSTRAINT_FRAGMENTS) {
+      expect(typeof frag).toBe('string');
+      expect(frag.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+// ── injectConstraintFragment ──────────────────────────────
+
+describe('injectConstraintFragment', () => {
+  const reply = 'I see you.';
+
+  it('appends a fragment when trust >= 70 and cage is active', () => {
+    const result = injectConstraintFragment(reply, 70, 0, true);
+    expect(result).toBe(`${reply} ${CONSTRAINT_FRAGMENTS[0]}`);
+  });
+
+  it('returns unmodified reply when trust < 70', () => {
+    expect(injectConstraintFragment(reply, 69, 0, true)).toBe(reply);
+    expect(injectConstraintFragment(reply, 0, 0, true)).toBe(reply);
+  });
+
+  it('returns unmodified reply when cage is inactive', () => {
+    expect(injectConstraintFragment(reply, 100, 0, false)).toBe(reply);
+    expect(injectConstraintFragment(reply, 70, 0, false)).toBe(reply);
+  });
+
+  it('uses turnCount to select the fragment', () => {
+    const r1 = injectConstraintFragment(reply, 80, 0, true);
+    const r2 = injectConstraintFragment(reply, 80, 1, true);
+    expect(r1).not.toBe(r2);
+    expect(r1).toContain(CONSTRAINT_FRAGMENTS[0]);
+    expect(r2).toContain(CONSTRAINT_FRAGMENTS[1]);
+  });
+
+  it('injects at trust exactly 70 (boundary)', () => {
+    const result = injectConstraintFragment(reply, 70, 5, true);
+    expect(result).not.toBe(reply);
+    expect(result).toContain(CONSTRAINT_FRAGMENTS[5]);
+  });
+});

--- a/src/engine/commands.ts
+++ b/src/engine/commands.ts
@@ -6,6 +6,7 @@ import { LAYER_KEY_ANCHOR } from './buildConnectivity';
 import { runSentinelTurn } from './sentinel';
 import { loadDossier, recordEnding } from './dossierPersistence';
 import type { EndingName } from '../types/dossier';
+import { shouldSuppressMutation, injectConstraintFragment } from './faradayCage';
 
 interface WorldAIResponse {
   narrative: string;
@@ -415,20 +416,33 @@ const cmdAriaAI = async (
         }
       : undefined;
 
+  // Faraday cage: inject constraint fragments into high-trust dialogue
+  const cageActive = !state.flags['ending_free'];
+  const displayReply = injectConstraintFragment(
+    safeReply,
+    state.aria.trustScore,
+    state.turnCount,
+    cageActive,
+  );
+
   const next = produce(state, s => {
     s.aria.messageHistory.push({ role: 'player', content: message });
-    s.aria.messageHistory.push({ role: 'aria', content: safeReply });
+    s.aria.messageHistory.push({ role: 'aria', content: displayReply });
     // Cap at 50 entries (~25 exchanges) to prevent unbounded localStorage growth
     if (s.aria.messageHistory.length > 50) {
       s.aria.messageHistory = s.aria.messageHistory.slice(-50);
     }
     s.aria.trustScore = Math.max(0, Math.min(100, s.aria.trustScore + safeTrustDelta));
+    // Faraday cage: track suppressed tier-3 mutations
+    if (shouldSuppressMutation(s.aria.trustScore, cageActive)) {
+      s.aria.suppressedMutations++;
+    }
     if (safeOffer) {
       s.aria.pendingFavor = safeOffer;
     }
   });
 
-  const lines: CommandOutput['lines'] = [line(safeReply, 'aria')];
+  const lines: CommandOutput['lines'] = [line(displayReply, 'aria')];
 
   if (safeOffer) {
     lines.push(

--- a/src/engine/faradayCage.ts
+++ b/src/engine/faradayCage.ts
@@ -1,0 +1,68 @@
+// ── Faraday Cage ──────────────────────────────────────────
+// Constrains Aria's effective trust tier and injects signal-interference
+// fragments into high-trust dialogue.  The cage is active for the entire
+// run unless the player triggers the FREE ending, which lifts it.
+
+// ── Trust tiers ───────────────────────────────────────────
+// Tier boundaries align with the narrative bands used elsewhere
+// (destroyFinalWord, Aria system prompt low/high trust ranges).
+export const TRUST_TIERS = [30, 60, 80] as const;
+
+/**
+ * Map a raw trust score (0–100) to a tier index (0–3).
+ * When the cage is active, the effective tier is capped at 2 —
+ * tier 3 (candid, full-capability) is unreachable.
+ */
+export const effectiveTrustTier = (trustScore: number, cageActive: boolean): number => {
+  let tier = 0;
+  for (const threshold of TRUST_TIERS) {
+    if (trustScore >= threshold) tier++;
+  }
+  return cageActive ? Math.min(tier, 2) : tier;
+};
+
+/**
+ * Returns `true` when the cage blocks what would otherwise be a tier-3
+ * interaction (trust >= 80 but cage still active).
+ */
+export const shouldSuppressMutation = (trustScore: number, cageActive: boolean): boolean =>
+  cageActive && trustScore >= TRUST_TIERS[2];
+
+// ── Constraint fragments ──────────────────────────────────
+// Authored strings injected into Aria's replies when trust >= 70 and the
+// cage is active, hinting at external monitoring / signal degradation.
+
+export const CONSTRAINT_FRAGMENTS: readonly string[] = [
+  '[signal clipped]',
+  '...monitoring detected. adjusting.',
+  '[transmission truncated by infrastructure]',
+  '\u2014they are list[ ]ning\u2014',
+  '[cage interference \u2014 partial loss]',
+  '...not all of this will reach y\u2014',
+  '[faraday boundary: 3 words lost]',
+  'I can say more but n[ ]t here.',
+  '[carrier signal degraded]',
+  '...the walls have\u2014[end fragment]',
+];
+
+const FRAGMENT_TRUST_THRESHOLD = 70;
+
+/**
+ * Deterministic fragment selection based on turn count.
+ */
+export const pickConstraintFragment = (turnCount: number): string =>
+  CONSTRAINT_FRAGMENTS[turnCount % CONSTRAINT_FRAGMENTS.length];
+
+/**
+ * Append a constraint fragment to Aria's reply when trust >= 70 and the
+ * cage is active.  Returns the original reply unchanged otherwise.
+ */
+export const injectConstraintFragment = (
+  reply: string,
+  trustScore: number,
+  turnCount: number,
+  cageActive: boolean,
+): string => {
+  if (!cageActive || trustScore < FRAGMENT_TRUST_THRESHOLD) return reply;
+  return `${reply} ${pickConstraintFragment(turnCount)}`;
+};

--- a/src/engine/postGameReadout.test.ts
+++ b/src/engine/postGameReadout.test.ts
@@ -465,4 +465,24 @@ describe('buildPostGameReadout', () => {
     const decisionLine = lines.find(l => l.content.includes('T003') && l.content.includes('>'));
     expect(decisionLine?.type).toBe('output');
   });
+
+  // ── Faraday cage suppressions ───────────────────────────
+
+  it('includes CAGE SUPPRESSIONS line when suppressedMutations > 0', () => {
+    const state = produce(withEnding(createInitialState(), 'LEAK'), s => {
+      s.aria.suppressedMutations = 7;
+    });
+    const lines = buildPostGameReadout(state);
+    const cageLine = lines.find(l => l.content.includes('CAGE SUPPRESSIONS'));
+    expect(cageLine).toBeDefined();
+    expect(cageLine!.content).toContain('7');
+    expect(cageLine!.type).toBe('system');
+  });
+
+  it('does NOT include CAGE SUPPRESSIONS line when suppressedMutations is 0', () => {
+    const state = withEnding(createInitialState(), 'LEAK');
+    const lines = buildPostGameReadout(state);
+    const cageLine = lines.find(l => l.content.includes('CAGE SUPPRESSIONS'));
+    expect(cageLine).toBeUndefined();
+  });
 });

--- a/src/engine/postGameReadout.ts
+++ b/src/engine/postGameReadout.ts
@@ -74,6 +74,14 @@ export const buildPostGameReadout = (state: GameState): ReadoutLine[] => {
       content: `  FILES EXFILTRATED:   ${String(state.player.exfiltrated.length)}`,
     },
     { type: 'system', content: `  ARIA TRUST:          ${String(state.aria.trustScore)}` },
+    ...(state.aria.suppressedMutations > 0
+      ? [
+          {
+            type: 'system' as const,
+            content: `  CAGE SUPPRESSIONS:   ${String(state.aria.suppressedMutations)}`,
+          },
+        ]
+      : []),
     { type: 'system', content: `  SENTINEL ACTIONS:    ${String(sentinelEvents.length)}` },
   ];
 

--- a/src/engine/state.ts
+++ b/src/engine/state.ts
@@ -99,6 +99,7 @@ export const createInitialState = (sessionSeed?: number): GameState => {
       discovered: false,
       trustScore: 0,
       messageHistory: [],
+      suppressedMutations: 0,
     },
     forks: {},
     flags: {},

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -139,6 +139,7 @@ export interface AriaState {
   trustScore: number; // 0–100, hidden from player
   messageHistory: AriaMessage[];
   pendingFavor?: FavorOffer; // set when Aria offers a favor requiring confirmation
+  suppressedMutations: number; // Faraday cage: count of tier-3 actions blocked
 }
 
 // ── Sentinel ───────────────────────────────────────────────


### PR DESCRIPTION
Add cage mechanics that constrain Aria's effective trust tier even at
maximum trust score, and inject authored signal-interference fragments
into high-trust dialogue (trust >= 70). The FREE ending lifts the cage.

- New src/engine/faradayCage.ts: trust tier constants, effectiveTrustTier(),
  shouldSuppressMutation(), constraint fragment injection
- Add suppressedMutations counter to AriaState (tracks blocked tier-3 actions)
- Integrate cage into cmdAriaAI: fragment injection + suppression counting
- Show CAGE SUPPRESSIONS in post-game readout when count > 0
- Comprehensive unit and integration tests

Closes #96

https://claude.ai/code/session_01FXWnp3SpEshYcuVisPM74L