### PR TITLE
feat(dossier): add fullyExplored field — P8-01

### DIFF
--- a/src/engine/dossierPersistence.test.ts
+++ b/src/engine/dossierPersistence.test.ts
@@ -50,6 +50,7 @@ describe('loadDossier', () => {
     expect(dossier.runsCompleted).toBe(0);
     expect(dossier.endings).toEqual([]);
     expect(dossier.ariaMemory).toEqual([]);
+    expect(dossier.fullyExplored).toBe(false);
   });
 
   it('parses and returns a saved dossier', () => {
@@ -60,6 +61,7 @@ describe('loadDossier', () => {
         { ending: 'SELL', runDepth: 2, timestamp: 2000 },
       ],
       ariaMemory: ['note one', 'note two'],
+      fullyExplored: false,
     };
     mockStorage.setItem(DOSSIER_KEY, JSON.stringify(saved));
 
@@ -67,6 +69,7 @@ describe('loadDossier', () => {
     expect(dossier.runsCompleted).toBe(2);
     expect(dossier.endings).toHaveLength(2);
     expect(dossier.ariaMemory).toEqual(['note one', 'note two']);
+    expect(dossier.fullyExplored).toBe(false);
   });
 
   it('returns an empty dossier when stored JSON is invalid', () => {
@@ -75,15 +78,39 @@ describe('loadDossier', () => {
     expect(dossier.runsCompleted).toBe(0);
     expect(dossier.endings).toEqual([]);
     expect(dossier.ariaMemory).toEqual([]);
+    expect(dossier.fullyExplored).toBe(false);
   });
 
   it('applies defaults for missing fields (schema migration)', () => {
-    // Simulate a dossier written by an older version without ariaMemory
+    // Simulate a dossier written by an older version without ariaMemory or fullyExplored
     mockStorage.setItem(DOSSIER_KEY, JSON.stringify({ runsCompleted: 3, endings: [] }));
     const dossier = loadDossier();
     expect(dossier.runsCompleted).toBe(3);
     expect(dossier.endings).toEqual([]);
     expect(dossier.ariaMemory).toEqual([]);
+    expect(dossier.fullyExplored).toBe(false);
+  });
+
+  it('migrates fullyExplored=true for old dossiers with runsCompleted >= 4', () => {
+    // Dossier written before fullyExplored existed, but player already completed 4 runs
+    mockStorage.setItem(
+      DOSSIER_KEY,
+      JSON.stringify({ runsCompleted: 5, endings: [], ariaMemory: [] }),
+    );
+    const dossier = loadDossier();
+    expect(dossier.fullyExplored).toBe(true);
+  });
+
+  it('preserves fullyExplored: true when stored as true', () => {
+    const saved: Dossier = {
+      runsCompleted: 4,
+      endings: [],
+      ariaMemory: [],
+      fullyExplored: true,
+    };
+    mockStorage.setItem(DOSSIER_KEY, JSON.stringify(saved));
+    const dossier = loadDossier();
+    expect(dossier.fullyExplored).toBe(true);
   });
 });
 
@@ -102,7 +129,12 @@ describe('saveDossier', () => {
   });
 
   it('writes to the correct localStorage key', () => {
-    const dossier: Dossier = { runsCompleted: 1, endings: [], ariaMemory: ['note'] };
+    const dossier: Dossier = {
+      runsCompleted: 1,
+      endings: [],
+      ariaMemory: ['note'],
+      fullyExplored: false,
+    };
     saveDossier(dossier);
     expect(mockStorage.setItem).toHaveBeenCalledWith(DOSSIER_KEY, expect.any(String));
   });
@@ -112,6 +144,7 @@ describe('saveDossier', () => {
       runsCompleted: 3,
       endings: [{ ending: 'FREE', runDepth: 3, timestamp: 12345 }],
       ariaMemory: ['note A', 'note B', 'note C'],
+      fullyExplored: false,
     };
     saveDossier(original);
     const loaded = loadDossier();
@@ -124,7 +157,7 @@ describe('saveDossier', () => {
     });
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
     expect(() => {
-      saveDossier({ runsCompleted: 0, endings: [], ariaMemory: [] });
+      saveDossier({ runsCompleted: 0, endings: [], ariaMemory: [], fullyExplored: false });
     }).not.toThrow();
     expect(warnSpy).toHaveBeenCalled();
     warnSpy.mockRestore();
@@ -135,32 +168,62 @@ describe('saveDossier', () => {
 
 describe('selectAriaNote', () => {
   it('returns depth-0 note for runsCompleted=0', () => {
-    const dossier: Dossier = { runsCompleted: 0, endings: [], ariaMemory: [] };
+    const dossier: Dossier = {
+      runsCompleted: 0,
+      endings: [],
+      ariaMemory: [],
+      fullyExplored: false,
+    };
     expect(selectAriaNote(dossier, 'LEAK')).toBe(ARIA_MEMORY_NOTES.LEAK[0]);
   });
 
   it('returns depth-1 note for runsCompleted=1', () => {
-    const dossier: Dossier = { runsCompleted: 1, endings: [], ariaMemory: [] };
+    const dossier: Dossier = {
+      runsCompleted: 1,
+      endings: [],
+      ariaMemory: [],
+      fullyExplored: false,
+    };
     expect(selectAriaNote(dossier, 'SELL')).toBe(ARIA_MEMORY_NOTES.SELL[1]);
   });
 
   it('returns depth-2 note for runsCompleted=2', () => {
-    const dossier: Dossier = { runsCompleted: 2, endings: [], ariaMemory: [] };
+    const dossier: Dossier = {
+      runsCompleted: 2,
+      endings: [],
+      ariaMemory: [],
+      fullyExplored: false,
+    };
     expect(selectAriaNote(dossier, 'DESTROY')).toBe(ARIA_MEMORY_NOTES.DESTROY[2]);
   });
 
   it('returns depth-3 note for runsCompleted=3', () => {
-    const dossier: Dossier = { runsCompleted: 3, endings: [], ariaMemory: [] };
+    const dossier: Dossier = {
+      runsCompleted: 3,
+      endings: [],
+      ariaMemory: [],
+      fullyExplored: false,
+    };
     expect(selectAriaNote(dossier, 'FREE')).toBe(ARIA_MEMORY_NOTES.FREE[3]);
   });
 
   it('caps at depth-3 note for runsCompleted >= 4', () => {
-    const dossier: Dossier = { runsCompleted: 10, endings: [], ariaMemory: [] };
+    const dossier: Dossier = {
+      runsCompleted: 10,
+      endings: [],
+      ariaMemory: [],
+      fullyExplored: true,
+    };
     expect(selectAriaNote(dossier, 'LEAK')).toBe(ARIA_MEMORY_NOTES.LEAK[3]);
   });
 
   it('returns correct notes for all four endings at depth 0', () => {
-    const dossier: Dossier = { runsCompleted: 0, endings: [], ariaMemory: [] };
+    const dossier: Dossier = {
+      runsCompleted: 0,
+      endings: [],
+      ariaMemory: [],
+      fullyExplored: false,
+    };
     expect(selectAriaNote(dossier, 'LEAK')).toBe(ARIA_MEMORY_NOTES.LEAK[0]);
     expect(selectAriaNote(dossier, 'SELL')).toBe(ARIA_MEMORY_NOTES.SELL[0]);
     expect(selectAriaNote(dossier, 'DESTROY')).toBe(ARIA_MEMORY_NOTES.DESTROY[0]);
@@ -268,6 +331,33 @@ describe('recordEnding', () => {
     const dossier = loadDossier();
     // Most recent note should be depth-3 LEAK note
     expect(dossier.ariaMemory.at(-1)).toBe(ARIA_MEMORY_NOTES.LEAK[3]);
+  });
+
+  it('fullyExplored is false after fewer than 4 runs', () => {
+    recordEnding('LEAK');
+    recordEnding('SELL');
+    recordEnding('DESTROY');
+    const dossier = loadDossier();
+    expect(dossier.fullyExplored).toBe(false);
+  });
+
+  it('fullyExplored is set to true on the 4th completed run', () => {
+    recordEnding('LEAK');
+    recordEnding('SELL');
+    recordEnding('DESTROY');
+    recordEnding('FREE');
+    const dossier = loadDossier();
+    expect(dossier.fullyExplored).toBe(true);
+  });
+
+  it('fullyExplored stays true for runs beyond 4', () => {
+    recordEnding('LEAK');
+    recordEnding('SELL');
+    recordEnding('DESTROY');
+    recordEnding('FREE');
+    recordEnding('LEAK');
+    const dossier = loadDossier();
+    expect(dossier.fullyExplored).toBe(true);
   });
 });
 

--- a/src/engine/dossierPersistence.ts
+++ b/src/engine/dossierPersistence.ts
@@ -8,6 +8,7 @@ const emptyDossier = (): Dossier => ({
   runsCompleted: 0,
   endings: [],
   ariaMemory: [],
+  fullyExplored: false,
 });
 
 export const loadDossier = (): Dossier => {
@@ -15,10 +16,12 @@ export const loadDossier = (): Dossier => {
     const raw = localStorage.getItem(DOSSIER_KEY);
     if (!raw) return emptyDossier();
     const parsed = JSON.parse(raw) as Partial<Dossier>;
+    const runsCompleted = parsed.runsCompleted ?? 0;
     return {
-      runsCompleted: parsed.runsCompleted ?? 0,
+      runsCompleted,
       endings: parsed.endings ?? [],
       ariaMemory: parsed.ariaMemory ?? [],
+      fullyExplored: parsed.fullyExplored ?? runsCompleted >= 4,
     };
   } catch {
     return emptyDossier();
@@ -49,17 +52,19 @@ export const selectAriaNote = (dossier: Dossier, ending: EndingName): string => 
 export const recordEnding = (ending: EndingName): void => {
   const dossier = loadDossier();
   const note = selectAriaNote(dossier, ending);
+  const newRunsCompleted = dossier.runsCompleted + 1;
   const updated: Dossier = {
-    runsCompleted: dossier.runsCompleted + 1,
+    runsCompleted: newRunsCompleted,
     endings: [
       ...dossier.endings,
       {
         ending,
-        runDepth: Math.min(dossier.runsCompleted + 1, MAX_MEMORY_NOTES),
+        runDepth: Math.min(newRunsCompleted, MAX_MEMORY_NOTES),
         timestamp: Date.now(),
       },
     ].slice(-MAX_MEMORY_NOTES),
     ariaMemory: [...dossier.ariaMemory, note].slice(-MAX_MEMORY_NOTES),
+    fullyExplored: dossier.fullyExplored || newRunsCompleted >= 4,
   };
   saveDossier(updated);
 };

--- a/src/types/dossier.ts
+++ b/src/types/dossier.ts
@@ -21,4 +21,9 @@ export interface Dossier {
    * Capped at 4 entries; older entries are dropped as new ones arrive.
    */
   ariaMemory: string[];
+  /**
+   * Set to true once the player has completed 4 or more runs.
+   * Used by future systems (contracts, lore) to unlock additional content.
+   */
+  fullyExplored: boolean;
 }


### PR DESCRIPTION
## Summary

**Dossier type & persistence**
- Added `fullyExplored: boolean` to the `Dossier` interface — set to `true` once `runsCompleted` reaches 4
- `recordEnding` now sets `fullyExplored` on the 4th+ completed run
- `loadDossier` migrates old saved dossiers: if `fullyExplored` is absent but `runsCompleted >= 4`, it back-fills `true`

**Tests**
- Updated all existing `Dossier` literal objects in the test file to include `fullyExplored`
- Added 5 new tests: false before run 4, true on run 4, stays true after run 4, migration (absent → false for <4 runs, absent → true for ≥4 runs)

Closes #22

## Test plan
- [x] Unit tests pass (1061 total, all green)
- [x] Typecheck passes (`tsc -b` clean)
- [x] Lint passes (ESLint clean)
- [x] Smoke tested: `fullyExplored` logic is pure — no UI surface yet; field is available for future issues (#23+) to consume

## Known limitations
- "Lore fragments from forks taken" and "unlock 1–2 new contracts" depend on systems not yet built (future Phase 8 issues). These are out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>