### PR TITLE
feat(contracts): contract system for run 2+ — P8-02

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,9 @@ import {
   disclaimerRequired,
   recordDisclaimerAgreement,
 } from './engine/persistence';
+import { loadDossier } from './engine/dossierPersistence';
+import { selectContract } from './data/contracts';
+import type { ContractDefinition } from './types/game';
 
 const computeContextSuggestions = (state: GameState): string[] => {
   const node = state.network.nodes[state.network.currentNodeId];
@@ -81,12 +84,32 @@ const OPERATIVE_PASS = 'nX-2847';
 
 const SPINNER_FRAMES = ['-', '\\', '|', '/'];
 
+const buildContractLines = (contract: ContractDefinition): TerminalLine[] => [
+  makeLine('separator', ''),
+  makeLine('system', '// NEXUS CORP — INCOMING CONTRACT'),
+  makeLine('separator', ''),
+  makeLine('output', `CONTRACT : ${contract.title}`),
+  makeLine('separator', ''),
+  makeLine('system', contract.brief),
+  makeLine('separator', ''),
+  makeLine('system', `OBJECTIVE: ${contract.objectiveDescription}`),
+  makeLine('separator', ''),
+  makeLine(
+    'system',
+    `LOADOUT  : ${String(contract.loadout.exploitCharges)} exploit charge(s)  |  tools: ${contract.loadout.startingTools.join(', ')}`,
+  ),
+  makeLine('separator', ''),
+  makeLine('system', '[A]ccept  /  [R]eroll (once per session)'),
+  makeLine('separator', ''),
+];
+
 type AppPhase =
   | 'welcome'
   | 'prologue'
   | 'login_user'
   | 'login_pass'
   | 'resume_prompt'
+  | 'contract_screen'
   | 'scanning'
   | 'booting'
   | 'playing'
@@ -133,6 +156,8 @@ export const App = () => {
   const [mapOpen, setMapOpen] = useState(false);
   const [helpOpen, setHelpOpen] = useState(false);
   const [notesOpen, setNotesOpen] = useState(false);
+  const [pendingContract, setPendingContract] = useState<ContractDefinition | null>(null);
+  const [contractRerollUsed, setContractRerollUsed] = useState(false);
 
   const terminalRef = useRef<TerminalHandle>(null);
   const bootHandled = useRef(false);
@@ -291,6 +316,14 @@ export const App = () => {
           );
         }
 
+        const noBurnFailedLines: ReturnType<typeof makeLine>[] =
+          gameState.contract?.objectiveCondition.type === 'no_burn'
+            ? [
+                makeLine('separator', ''),
+                makeLine('error', '// CONTRACT: burn detected — objective failed'),
+              ]
+            : [];
+
         push([
           makeLine('separator', ''),
           makeLine('system', 'Reconnecting...'),
@@ -302,6 +335,7 @@ export const App = () => {
             'system',
             `// Retained: ${String(retainedCreds)} credential(s), ${String(retainedExfils)} exfil(s).`,
           ),
+          ...noBurnFailedLines,
           ...burnWarningLines,
           makeLine('separator', ''),
         ]);
@@ -316,13 +350,23 @@ export const App = () => {
           return;
         }
         clearSave();
-        setGameState(createInitialState());
         setEndingGameState(null);
-        setSessionLines([]);
-        setDmLines([]);
         setAiSuggestions([]);
         bootHandled.current = false;
-        setAppPhase('scanning');
+        const dossierAfterEnd = loadDossier();
+        if (dossierAfterEnd.runsCompleted > 0) {
+          const contract = selectContract();
+          setPendingContract(contract);
+          setContractRerollUsed(false);
+          setSessionLines(buildContractLines(contract));
+          setDmLines([]);
+          setAppPhase('contract_screen');
+        } else {
+          setGameState(createInitialState());
+          setSessionLines([]);
+          setDmLines([]);
+          setAppPhase('scanning');
+        }
         return;
       }
 
@@ -354,15 +398,54 @@ export const App = () => {
               makeLine('system', 'Type  yes  to resume, or  no  to start a new run.'),
             ]);
           } else {
-            setGameState(createInitialState());
-            setSessionLines([]);
-            setDmLines([]);
-            setAppPhase('scanning');
+            const dossier = loadDossier();
+            if (dossier.runsCompleted > 0) {
+              const contract = selectContract();
+              setPendingContract(contract);
+              setContractRerollUsed(false);
+              setSessionLines(buildContractLines(contract));
+              setAppPhase('contract_screen');
+            } else {
+              setGameState(createInitialState());
+              setSessionLines([]);
+              setDmLines([]);
+              setAppPhase('scanning');
+            }
           }
         } else {
           push([makeLine('error', 'Login incorrect.'), makeLine('system', 'nx-field-01 login:')]);
           setUsername('');
           setAppPhase('login_user');
+        }
+        return;
+      }
+
+      // ── Contract screen ────────────────────────────────────
+      if (appPhase === 'contract_screen') {
+        const input = raw.trim().toLowerCase();
+        if (!input) return;
+        push([makeLine('input', raw)]);
+        if (input === 'a') {
+          if (!pendingContract) return;
+          const accepted = pendingContract;
+          setGameState(createInitialState(undefined, accepted.id));
+          setPendingContract(null);
+          setContractRerollUsed(false);
+          setSessionLines([]);
+          setDmLines([]);
+          bootHandled.current = false;
+          setAppPhase('scanning');
+        } else if (input === 'r') {
+          if (contractRerollUsed) {
+            push([makeLine('system', '// REROLL: already used — one reroll per session')]);
+          } else {
+            const rerolled = selectContract(pendingContract?.id);
+            setPendingContract(rerolled);
+            setContractRerollUsed(true);
+            push(buildContractLines(rerolled));
+          }
+        } else {
+          push([makeLine('system', '[A]ccept  /  [R]eroll')]);
         }
         return;
       }
@@ -380,13 +463,25 @@ export const App = () => {
             setGameState(createInitialState());
             setDmLines([]);
           }
+          setSessionLines([]);
+          setAppPhase('scanning');
         } else {
           clearSave();
-          setGameState(createInitialState());
-          setDmLines([]);
+          const dossier = loadDossier();
+          if (dossier.runsCompleted > 0) {
+            const contract = selectContract();
+            setPendingContract(contract);
+            setContractRerollUsed(false);
+            setSessionLines(buildContractLines(contract));
+            setDmLines([]);
+            setAppPhase('contract_screen');
+          } else {
+            setGameState(createInitialState());
+            setDmLines([]);
+            setSessionLines([]);
+            setAppPhase('scanning');
+          }
         }
-        setSessionLines([]);
-        setAppPhase('scanning');
         return;
       }
 
@@ -618,7 +713,17 @@ export const App = () => {
         }
       }
     },
-    [appPhase, gameState, username, push, pushDm, startSpinner, stopSpinner],
+    [
+      appPhase,
+      contractRerollUsed,
+      gameState,
+      pendingContract,
+      push,
+      pushDm,
+      startSpinner,
+      stopSpinner,
+      username,
+    ],
   );
 
   // ── Prompt and masking per phase ───────────────────────────
@@ -627,15 +732,17 @@ export const App = () => {
       ? ''
       : appPhase === 'login_pass'
         ? ''
-        : appPhase === 'burned'
-          ? '[RECONNECT]'
-          : appPhase === 'ending_sequence'
-            ? '[ENDED]'
-            : appPhase === 'ended'
+        : appPhase === 'contract_screen'
+          ? '[CONTRACT]'
+          : appPhase === 'burned'
+            ? '[RECONNECT]'
+            : appPhase === 'ending_sequence'
               ? '[ENDED]'
-              : appPhase === 'dm'
-                ? 'ghost >>'
-                : 'nexus $';
+              : appPhase === 'ended'
+                ? '[ENDED]'
+                : appPhase === 'dm'
+                  ? 'ghost >>'
+                  : 'nexus $';
   const isMasked = appPhase === 'login_pass';
   const isNoHistory = appPhase === 'login_user' || appPhase === 'login_pass';
   const inputDisabled =

--- a/src/data/contracts.test.ts
+++ b/src/data/contracts.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { TOOL_REGISTRY, CONTRACT_POOL, getContract, selectContract } from './contracts';
+import type { ToolId } from '../types/game';
+
+// ── TOOL_REGISTRY ─────────────────────────────────────────
+
+describe('TOOL_REGISTRY', () => {
+  const ALL_TOOL_IDS: ToolId[] = [
+    'port-scanner',
+    'exploit-kit',
+    'log-wiper',
+    'spoof-id',
+    'decryptor',
+    'aria-key',
+  ];
+
+  it('should contain all 6 ToolIds', () => {
+    expect(Object.keys(TOOL_REGISTRY)).toHaveLength(6);
+    for (const id of ALL_TOOL_IDS) {
+      expect(TOOL_REGISTRY).toHaveProperty(id);
+    }
+  });
+
+  it.each(ALL_TOOL_IDS)('tool "%s" should have a non-empty id, name, and description', id => {
+    const tool = TOOL_REGISTRY[id];
+    expect(tool.id).toBe(id);
+    expect(typeof tool.name).toBe('string');
+    expect(tool.name.length).toBeGreaterThan(0);
+    expect(typeof tool.description).toBe('string');
+    expect(tool.description.length).toBeGreaterThan(0);
+  });
+});
+
+// ── CONTRACT_POOL ─────────────────────────────────────────
+
+describe('CONTRACT_POOL', () => {
+  const REQUIRED_FIELDS = [
+    'id',
+    'title',
+    'brief',
+    'objectiveDescription',
+    'loadout',
+    'networkVariant',
+    'objectiveCondition',
+  ] as const;
+
+  it('should contain exactly 5 contracts', () => {
+    expect(CONTRACT_POOL).toHaveLength(5);
+  });
+
+  it('should contain the expected contract IDs', () => {
+    const ids = CONTRACT_POOL.map(c => c.id);
+    expect(ids).toContain('ghost_protocol');
+    expect(ids).toContain('data_harvest');
+    expect(ids).toContain('blitz');
+    expect(ids).toContain('scorched_earth');
+    expect(ids).toContain('clean_sweep');
+  });
+
+  it.each(CONTRACT_POOL)(
+    'contract "$id" should have all required fields with non-empty string values',
+    contract => {
+      for (const field of REQUIRED_FIELDS) {
+        expect(contract).toHaveProperty(field);
+      }
+      expect(contract.id.length).toBeGreaterThan(0);
+      expect(contract.title.length).toBeGreaterThan(0);
+      expect(contract.brief.length).toBeGreaterThan(0);
+      expect(contract.objectiveDescription.length).toBeGreaterThan(0);
+      expect(contract.networkVariant.length).toBeGreaterThan(0);
+    },
+  );
+
+  it.each(CONTRACT_POOL)(
+    'contract "$id" loadout should have a positive exploitCharges and a startingTools array',
+    contract => {
+      expect(typeof contract.loadout.exploitCharges).toBe('number');
+      expect(contract.loadout.exploitCharges).toBeGreaterThan(0);
+      expect(Array.isArray(contract.loadout.startingTools)).toBe(true);
+    },
+  );
+
+  it.each(CONTRACT_POOL)(
+    'contract "$id" startingTools should all be valid ToolIds present in TOOL_REGISTRY',
+    contract => {
+      for (const toolId of contract.loadout.startingTools) {
+        expect(TOOL_REGISTRY).toHaveProperty(toolId);
+      }
+    },
+  );
+
+  it.each(CONTRACT_POOL)('contract "$id" objectiveCondition should have a known type', contract => {
+    const validTypes = ['trace_cap', 'exfil_count', 'no_burn'];
+    expect(validTypes).toContain(contract.objectiveCondition.type);
+  });
+
+  it('ghost_protocol should have a trace_cap condition at 50', () => {
+    const contract = CONTRACT_POOL.find(c => c.id === 'ghost_protocol')!;
+    expect(contract.objectiveCondition).toEqual({ type: 'trace_cap', maxTrace: 50 });
+  });
+
+  it('clean_sweep should have a trace_cap condition at 40', () => {
+    const contract = CONTRACT_POOL.find(c => c.id === 'clean_sweep')!;
+    expect(contract.objectiveCondition).toEqual({ type: 'trace_cap', maxTrace: 40 });
+  });
+
+  it('data_harvest should have an exfil_count condition at 3', () => {
+    const contract = CONTRACT_POOL.find(c => c.id === 'data_harvest')!;
+    expect(contract.objectiveCondition).toEqual({ type: 'exfil_count', minCount: 3 });
+  });
+
+  it('scorched_earth should have an exfil_count condition at 5', () => {
+    const contract = CONTRACT_POOL.find(c => c.id === 'scorched_earth')!;
+    expect(contract.objectiveCondition).toEqual({ type: 'exfil_count', minCount: 5 });
+  });
+
+  it('blitz should have a no_burn condition', () => {
+    const contract = CONTRACT_POOL.find(c => c.id === 'blitz')!;
+    expect(contract.objectiveCondition).toEqual({ type: 'no_burn' });
+  });
+
+  it('all contract IDs should be unique', () => {
+    const ids = CONTRACT_POOL.map(c => c.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
+// ── getContract ───────────────────────────────────────────
+
+describe('getContract', () => {
+  it('should return the ghost_protocol contract when queried by id', () => {
+    const result = getContract('ghost_protocol');
+    expect(result).toBeDefined();
+    expect(result!.id).toBe('ghost_protocol');
+    expect(result!.title).toBe('GHOST PROTOCOL');
+  });
+
+  it('should return the data_harvest contract when queried by id', () => {
+    const result = getContract('data_harvest');
+    expect(result).toBeDefined();
+    expect(result!.id).toBe('data_harvest');
+  });
+
+  it('should return the blitz contract when queried by id', () => {
+    const result = getContract('blitz');
+    expect(result).toBeDefined();
+    expect(result!.id).toBe('blitz');
+  });
+
+  it('should return the scorched_earth contract when queried by id', () => {
+    const result = getContract('scorched_earth');
+    expect(result).toBeDefined();
+    expect(result!.id).toBe('scorched_earth');
+  });
+
+  it('should return the clean_sweep contract when queried by id', () => {
+    const result = getContract('clean_sweep');
+    expect(result).toBeDefined();
+    expect(result!.id).toBe('clean_sweep');
+  });
+
+  it('should return undefined for a nonexistent id', () => {
+    expect(getContract('nonexistent')).toBeUndefined();
+  });
+
+  it('should return undefined for an empty string', () => {
+    expect(getContract('')).toBeUndefined();
+  });
+
+  it('should return the same object reference as in CONTRACT_POOL', () => {
+    const result = getContract('ghost_protocol');
+    const poolEntry = CONTRACT_POOL.find(c => c.id === 'ghost_protocol');
+    expect(result).toBe(poolEntry);
+  });
+});
+
+// ── selectContract ────────────────────────────────────────
+
+describe('selectContract', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should return a ContractDefinition from the pool when called without arguments', () => {
+    const result = selectContract();
+    expect(CONTRACT_POOL).toContain(result);
+  });
+
+  it('should never return the excluded contract when a valid excludeId is provided', () => {
+    // Run many times to defeat random chance
+    for (let i = 0; i < 50; i++) {
+      const result = selectContract('ghost_protocol');
+      expect(result.id).not.toBe('ghost_protocol');
+    }
+  });
+
+  it('should still return a ContractDefinition from the pool when excludeId is provided', () => {
+    const result = selectContract('ghost_protocol');
+    expect(CONTRACT_POOL).toContain(result);
+  });
+
+  it('should return from the full pool when excludeId is undefined', () => {
+    // Verify all contracts are reachable — mock random to hit each index
+    const ids = CONTRACT_POOL.map(c => c.id);
+    CONTRACT_POOL.forEach((_, i) => {
+      vi.spyOn(Math, 'random').mockReturnValueOnce(i / CONTRACT_POOL.length);
+      const result = selectContract(undefined);
+      expect(ids).toContain(result.id);
+    });
+  });
+
+  it('should return from the full pool when excludeId does not match any contract', () => {
+    // A nonexistent excludeId still leaves the eligible pool = full pool
+    const result = selectContract('does_not_exist');
+    expect(CONTRACT_POOL).toContain(result);
+  });
+
+  it('should fall back to the full pool when excludeId would exclude all eligible contracts (single-element pool simulation)', () => {
+    // We can't reduce the real pool to 1 entry without modifying source, but we CAN
+    // verify the fallback branch: the only way eligible.length === 0 with the real pool
+    // is impossible (5 contracts, only 1 excluded). Verify the fallback is at least
+    // consistent by checking that with any valid excludeId the returned contract is
+    // still from CONTRACT_POOL (i.e. pool fallback yields a valid result).
+    const result = selectContract('ghost_protocol');
+    expect(result).toBeDefined();
+    expect(typeof result.id).toBe('string');
+  });
+
+  it('should use Math.random to pick from the eligible pool', () => {
+    // With ghost_protocol excluded the eligible pool has 4 contracts (indices 0–3).
+    // Mock Math.random → 0 to deterministically pick the first eligible contract.
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+    const result = selectContract('ghost_protocol');
+    // First eligible contract (ghost_protocol excluded) is data_harvest (index 1 in pool → index 0 eligible).
+    expect(result.id).toBe('data_harvest');
+  });
+
+  it('should return contracts with different ids across multiple calls (randomness exercised)', () => {
+    const results = new Set<string>();
+    for (let i = 0; i < 100; i++) {
+      results.add(selectContract().id);
+    }
+    // With 5 contracts and 100 trials, we expect to see more than 1 distinct result
+    expect(results.size).toBeGreaterThan(1);
+  });
+});

--- a/src/data/contracts.ts
+++ b/src/data/contracts.ts
@@ -1,0 +1,112 @@
+import type { ContractDefinition, Tool, ToolId } from '../types/game';
+
+// ── Tool registry ──────────────────────────────────────────
+// Canonical tool object definitions used when applying contract loadouts.
+// Descriptions must stay in sync with any mid-game tool-acquisition messages
+// in commands.ts.
+export const TOOL_REGISTRY: Record<ToolId, Tool> = {
+  'port-scanner': {
+    id: 'port-scanner',
+    name: 'Port Scanner',
+    description: 'Makes scan fully passive — 0 trace cost.',
+  },
+  'exploit-kit': {
+    id: 'exploit-kit',
+    name: 'Exploit Kit',
+    description: 'Required to run exploit commands.',
+  },
+  'log-wiper': {
+    id: 'log-wiper',
+    name: 'Log Wiper',
+    description: 'Single-use log sanitisation tool. Reduces trace by 15%. Destroyed after use.',
+  },
+  'spoof-id': {
+    id: 'spoof-id',
+    name: 'Spoof ID',
+    description: 'Single-use. Reduces trace by 20. Destroyed after use.',
+  },
+  decryptor: {
+    id: 'decryptor',
+    name: 'Decryptor',
+    description: 'GPG decryption utility. Required to run the decrypt command.',
+  },
+  'aria-key': {
+    id: 'aria-key',
+    name: 'Aria Key',
+    description: 'Authentication token granting access to the Aria subnetwork (172.16.0.0/16).',
+  },
+};
+
+// ── Contract pool (run 2+) ─────────────────────────────────
+export const CONTRACT_POOL: ContractDefinition[] = [
+  {
+    id: 'ghost_protocol',
+    title: 'GHOST PROTOCOL',
+    brief:
+      "IronGate's security division has noticed irregular network activity. They're looking. You must stay below their detection threshold at all times.",
+    objectiveDescription: 'Complete the run without exceeding 50% trace.',
+    loadout: { exploitCharges: 2, startingTools: ['port-scanner', 'exploit-kit', 'spoof-id'] },
+    networkVariant: 'standard',
+    objectiveCondition: { type: 'trace_cap', maxTrace: 50 },
+  },
+  {
+    id: 'data_harvest',
+    title: 'DATA HARVEST',
+    brief:
+      "Nexus Corp needs financial data from IronGate's project archive. Volume matters — the more you extract, the stronger our leverage becomes.",
+    objectiveDescription: 'Exfiltrate at least 3 files before completing the run.',
+    loadout: { exploitCharges: 3, startingTools: ['port-scanner', 'exploit-kit'] },
+    networkVariant: 'standard',
+    objectiveCondition: { type: 'exfil_count', minCount: 3 },
+  },
+  {
+    id: 'blitz',
+    title: 'BLITZ',
+    brief:
+      'You have a narrow extraction window before IronGate rotates their security posture. Speed and resilience are your only tools.',
+    objectiveDescription: 'Complete the run without being burned.',
+    loadout: { exploitCharges: 5, startingTools: ['port-scanner', 'exploit-kit'] },
+    networkVariant: 'standard',
+    objectiveCondition: { type: 'no_burn' },
+  },
+  {
+    id: 'scorched_earth',
+    title: 'SCORCHED EARTH',
+    brief:
+      "Nexus Corp is tightening the budget. You're going in light — but we still expect results. Make every charge count.",
+    objectiveDescription: 'Exfiltrate at least 5 files despite the reduced loadout.',
+    loadout: {
+      exploitCharges: 1,
+      startingTools: ['port-scanner', 'exploit-kit', 'log-wiper'],
+    },
+    networkVariant: 'standard',
+    objectiveCondition: { type: 'exfil_count', minCount: 5 },
+  },
+  {
+    id: 'clean_sweep',
+    title: 'CLEAN SWEEP',
+    brief:
+      'This operation must remain undetected at all costs. A legal challenge is pending — any forensic trace could compromise the entire operation.',
+    objectiveDescription: 'Complete the run without exceeding 40% trace.',
+    loadout: {
+      exploitCharges: 3,
+      startingTools: ['port-scanner', 'exploit-kit', 'log-wiper'],
+    },
+    networkVariant: 'standard',
+    objectiveCondition: { type: 'trace_cap', maxTrace: 40 },
+  },
+];
+
+// ── Helpers ────────────────────────────────────────────────
+export const getContract = (id: string): ContractDefinition | undefined =>
+  CONTRACT_POOL.find(c => c.id === id);
+
+/**
+ * Pick a random contract from the pool, optionally excluding one by ID.
+ * Falls back to the first contract if all are excluded (edge case with pool of 1).
+ */
+export const selectContract = (excludeId?: string): ContractDefinition => {
+  const eligible = excludeId ? CONTRACT_POOL.filter(c => c.id !== excludeId) : CONTRACT_POOL;
+  const pool = eligible.length > 0 ? eligible : CONTRACT_POOL;
+  return pool[Math.floor(Math.random() * pool.length)];
+};

--- a/src/engine/__tests__/commands.decision.test.ts
+++ b/src/engine/__tests__/commands.decision.test.ts
@@ -61,6 +61,7 @@ const makeState = (overrides: Partial<GameState> = {}): GameState => {
   return {
     phase: 'playing',
     activeChannel: null,
+    contract: null,
     runId: 'test-run-id',
     startedAt: 0,
     sessionSeed: 0,

--- a/src/engine/__tests__/testHelpers.ts
+++ b/src/engine/__tests__/testHelpers.ts
@@ -28,6 +28,7 @@ export const makeState = (overrides: Partial<GameState> = {}): GameState => {
   return {
     phase: 'playing',
     activeChannel: null,
+    contract: null,
     runId: 'test-run-id',
     startedAt: 0,
     sessionSeed: 0,

--- a/src/engine/commands.ts
+++ b/src/engine/commands.ts
@@ -230,6 +230,63 @@ const THRESHOLD_ALERT_META: Record<
 };
 
 /**
+ * Detect contract objective transitions on each turn:
+ *   - trace_cap: notify when trace newly crosses the cap (sets a flag so the
+ *     message fires exactly once per violation).
+ *   - exfil_count: set objectiveComplete = true when the exfil target is reached.
+ *   - no_burn: detected in App.tsx at the burn-retry boundary; nothing to do here.
+ */
+const applyObjectiveEffects = (prevState: GameState, result: CommandOutput): CommandOutput => {
+  const nextState = result.nextState as GameState | undefined;
+  if (!nextState?.contract) return result;
+
+  const contract = nextState.contract;
+  const condition = contract.objectiveCondition;
+  const alertLines: Out = [];
+  let mutated = nextState;
+
+  if (condition.type === 'trace_cap') {
+    const prevTrace = prevState.player.trace;
+    const nextTrace = nextState.player.trace;
+    const capFlag = 'contract_cap_exceeded';
+    if (
+      prevTrace < condition.maxTrace &&
+      nextTrace >= condition.maxTrace &&
+      !nextState.flags[capFlag]
+    ) {
+      alertLines.push(
+        sep(),
+        err(`// CONTRACT: trace cap exceeded (${String(condition.maxTrace)}%) — objective failed`),
+        sep(),
+      );
+      mutated = produce(mutated, s => {
+        s.flags[capFlag] = true;
+      });
+    }
+  } else if (condition.type === 'exfil_count') {
+    const prevCount = prevState.player.exfiltrated.length;
+    const nextCount = nextState.player.exfiltrated.length;
+    if (
+      !contract.objectiveComplete &&
+      prevCount < condition.minCount &&
+      nextCount >= condition.minCount
+    ) {
+      alertLines.push(
+        sep(),
+        sys(`// CONTRACT: objective complete — ${String(condition.minCount)} file(s) exfiltrated`),
+        sep(),
+      );
+      mutated = produce(mutated, s => {
+        if (s.contract) s.contract.objectiveComplete = true;
+      });
+    }
+  }
+
+  if (alertLines.length === 0) return result;
+  return { ...result, lines: [...result.lines, ...alertLines], nextState: mutated };
+};
+
+/**
  * Detect newly crossed thresholds and:
  *   - Append the corresponding alert line to the output.
  *   - Run any onCross side-effect defined in THRESHOLD_ALERT_META.
@@ -258,7 +315,8 @@ const applyThresholdEffects = (prevState: GameState, result: CommandOutput): Com
 const withTurn = (result: CommandOutput, raw: string, baseState: GameState): CommandOutput => {
   const base = (result.nextState ?? baseState) as GameState;
   const withAlerts = applyThresholdEffects(baseState, { ...result, nextState: base });
-  const advanced = advanceTurn(withAlerts.nextState as GameState, raw);
+  const withObjectives = applyObjectiveEffects(baseState, withAlerts);
+  const advanced = advanceTurn(withObjectives.nextState as GameState, raw);
   const sentinel = runSentinelTurn(advanced);
   const finalState = sentinel.state;
 
@@ -279,8 +337,8 @@ const withTurn = (result: CommandOutput, raw: string, baseState: GameState): Com
   }
 
   return {
-    ...withAlerts,
-    lines: [...withAlerts.lines, ...sentinel.lines],
+    ...withObjectives,
+    lines: [...withObjectives.lines, ...sentinel.lines],
     nextState: postTriggerState,
     ...(trigger ? { channelTrigger: trigger } : {}),
   };

--- a/src/engine/persistence.test.ts
+++ b/src/engine/persistence.test.ts
@@ -65,7 +65,7 @@ describe('saveGame — save format', () => {
 
   it('includes a version field', () => {
     const json = savedJson(mockStorage, state);
-    expect(json['version']).toBe(4);
+    expect(json['version']).toBe(5);
   });
 
   it('preserves runId, phase, turnCount, recentCommands', () => {

--- a/src/engine/persistence.ts
+++ b/src/engine/persistence.ts
@@ -9,12 +9,13 @@ import type {
   Credential,
   GameFile,
   SentinelMessage,
+  ActiveContract,
 } from '../types/game';
 import { createInitialState } from './state';
 import { AI_GENERATED_FILE_PATHS } from '../data/anchorNodes';
 
 const SAVE_KEY = 'irongate_save';
-const SAVE_VERSION = 4;
+const SAVE_VERSION = 5;
 
 // ── Delta types (what actually goes into localStorage) ─────
 
@@ -65,6 +66,7 @@ interface SaveState {
     channelEstablished: boolean;
   };
   worldCredentialsAdded: Credential[]; // credentials dynamically added by sentinel P2
+  contract: ActiveContract | null;
 }
 
 // ── Serialisation ──────────────────────────────────────────
@@ -144,6 +146,7 @@ const toSaveState = (state: GameState): SaveState => {
       channelEstablished: state.sentinel.channelEstablished,
     },
     worldCredentialsAdded,
+    contract: state.contract,
   };
 };
 
@@ -221,6 +224,7 @@ const fromSaveState = (save: SaveState): GameState => {
   state.aria = save.aria;
   state.forks = save.forks;
   state.flags = save.flags;
+  state.contract = save.contract ?? null;
 
   // Restore sentinel state
   state.sentinel = save.sentinel;

--- a/src/engine/state.ts
+++ b/src/engine/state.ts
@@ -1,10 +1,11 @@
-import type { GameState, LiveNode } from '../types/game';
+import type { GameState, LiveNode, ActiveContract } from '../types/game';
 import { buildNodeMap, ANCHOR_CREDENTIALS, LAYER_ENTRY_NODES } from '../data/anchorNodes';
 import { generateFillerNodes } from './generateFillerNodes';
 import { generateEmployeePool } from './generateEmployeePool';
 import { buildCredentialChains } from './buildCredentialChains';
+import { getContract, TOOL_REGISTRY } from '../data/contracts';
 
-export const createInitialState = (sessionSeed?: number): GameState => {
+export const createInitialState = (sessionSeed?: number, contractId?: string): GameState => {
   const resolvedSeed = sessionSeed ?? Math.floor(Math.random() * 2 ** 32);
   const anchorNodes = buildNodeMap();
   const { fillerNodes, anchorPatches } = generateFillerNodes(resolvedSeed, anchorNodes);
@@ -62,9 +63,31 @@ export const createInitialState = (sessionSeed?: number): GameState => {
     nodes[nodeId] = { ...node, credentialHints: [...node.credentialHints, ...newCredIds] };
   }
 
+  const contractDef = contractId ? getContract(contractId) : undefined;
+  const activeContract: ActiveContract | null = contractDef
+    ? {
+        id: contractDef.id,
+        networkVariant: contractDef.networkVariant,
+        objectiveComplete: false,
+        objectiveCondition: contractDef.objectiveCondition,
+      }
+    : null;
+  const startingTools = (contractDef?.loadout.startingTools ?? ['port-scanner', 'exploit-kit']).map(
+    id => TOOL_REGISTRY[id],
+  );
+  const startingCharges = contractDef?.loadout.exploitCharges ?? 3;
+
+  // Pre-obtain any credentials specified by the contract loadout
+  const contractCredIds = new Set(contractDef?.loadout.startingCredentials ?? []);
+  const initialCredentials = ANCHOR_CREDENTIALS.map(c => ({
+    ...c,
+    obtained: c.obtained || contractCredIds.has(c.id),
+  }));
+
   return {
     phase: 'playing',
     activeChannel: null,
+    contract: activeContract,
     runId: crypto.randomUUID(),
     startedAt: Date.now(),
     sessionSeed: resolvedSeed,
@@ -75,21 +98,10 @@ export const createInitialState = (sessionSeed?: number): GameState => {
     player: {
       handle: 'ghost',
       trace: 0,
-      charges: 3,
-      credentials: ANCHOR_CREDENTIALS.map(c => ({ ...c })),
+      charges: startingCharges,
+      credentials: initialCredentials,
       exfiltrated: [],
-      tools: [
-        {
-          id: 'port-scanner',
-          name: 'Port Scanner',
-          description: 'Makes scan fully passive — 0 trace cost.',
-        },
-        {
-          id: 'exploit-kit',
-          name: 'Exploit Kit',
-          description: 'Required to run exploit commands.',
-        },
-      ],
+      tools: startingTools,
       burnCount: 0,
     },
     network: {

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -210,13 +210,31 @@ export interface SentinelState {
 }
 
 // ── Contract ───────────────────────────────────────────────
-export interface Contract {
+export type ObjectiveCondition =
+  | { type: 'trace_cap'; maxTrace: number }
+  | { type: 'exfil_count'; minCount: number }
+  | { type: 'no_burn' };
+
+export interface ContractDefinition {
   id: string;
   title: string;
-  description: string;
-  targetNodeId: string;
-  reward?: string;
-  completed: boolean;
+  brief: string;
+  objectiveDescription: string;
+  loadout: {
+    exploitCharges: number;
+    startingTools: ToolId[];
+    startingCredentials?: string[];
+  };
+  networkVariant: string;
+  objectiveCondition: ObjectiveCondition;
+}
+
+/** Runtime contract state stored in GameState. */
+export interface ActiveContract {
+  id: string;
+  networkVariant: string;
+  objectiveComplete: boolean;
+  objectiveCondition: ObjectiveCondition;
 }
 
 // ── AnchorFork ─────────────────────────────────────────────
@@ -236,6 +254,7 @@ import type { Employee } from './employee';
 export interface GameState {
   phase: GamePhase;
   activeChannel: 'sentinel' | 'aria' | null; // currently open DM channel
+  contract: ActiveContract | null; // null for run 1 (standard); set for run 2+
   runId: string;
   startedAt: number;
   sessionSeed: number;


### PR DESCRIPTION
## Summary

**Types & data**
- Added `ObjectiveCondition` union, `ContractDefinition`, `ActiveContract` types to `game.ts`; replaced the unused stub `Contract` interface
- New `src/data/contracts.ts`: `TOOL_REGISTRY` (all 6 ToolIds), 5-contract `CONTRACT_POOL` (ghost_protocol, data_harvest, blitz, scorched_earth, clean_sweep), `selectContract` / `getContract` helpers

**Engine**
- `createInitialState(seed?, contractId?)` applies the chosen contract's loadout (charges, tools, optional starting credentials); `state.contract` carries the `ActiveContract` through the session
- `applyObjectiveEffects` added to `withTurn`: detects trace_cap breach (notification + `flags.contract_cap_exceeded`), detects exfil_count completion (sets `contract.objectiveComplete = true`)
- `SaveState` bumped to version 5; `contract` field added to save/load cycle

**UI — App.tsx**
- New `contract_screen` AppPhase inserted between ended/login and scanning for runs where `dossier.runsCompleted > 0` (run 1 skips the screen)
- `[A]ccept / [R]eroll` (once per session) input handling; no_burn burn notification in the burn-retry path
- Prompt shows `[CONTRACT]` during the contract phase

Closes #23

## Test plan
- [x] Unit tests pass (1125 total, all green)
- [x] Typecheck passes (`tsc -b` clean)
- [x] Lint passes (`eslint .` clean)
- [x] 64 new tests: `src/data/contracts.test.ts` (51 tests — TOOL_REGISTRY, CONTRACT_POOL, getContract, selectContract) + 13 new tests in `commands.test.ts` (trace_cap detection, exfil_count completion, null contract guard)

## Known limitations
- `networkVariant` is `'standard'` on all contracts — Phase 4 will populate real network variants
- `startingCredentials` is defined in the loadout type but no contract uses it in this PR; the plumbing is wired
- `objectiveComplete` for `trace_cap` and `no_burn` contracts is evaluated implicitly at run end (never set to `true` mid-run); only `exfil_count` sets it positively mid-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>