### PR TITLE
feat(engine): §9.4 Aria mutations — reroute edge and delete reinforcement

### DIFF
--- a/src/engine/__tests__/ariaMutations.test.ts
+++ b/src/engine/__tests__/ariaMutations.test.ts
@@ -1,0 +1,608 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { runAriaTurn } from '../ariaMutations';
+import { makeNode, makeState } from './testHelpers';
+import type { GameState, LiveNode } from '../../types/game';
+
+// ── State factories ────────────────────────────────────────
+// Player at layer 5 → LAYER_KEY_ANCHOR[5] is undefined → all three §9.5 checks
+// return true by default, so isGameCompletable() never blocks a mutation here.
+
+const makeAriaState = (overrides: Partial<GameState> = {}): GameState => {
+  const current = makeNode({ id: 'current', ip: '10.5.0.1', layer: 5, connections: [] });
+  return makeState({
+    network: {
+      currentNodeId: 'current',
+      previousNodeId: null,
+      nodes: { current },
+    },
+    aria: {
+      discovered: true,
+      trustScore: 60,
+      messageHistory: [],
+      suppressedMutations: 0,
+    },
+    ...overrides,
+  });
+};
+
+const makeSentinelNode = (n: number, extra: Partial<LiveNode> = {}): LiveNode =>
+  makeNode({
+    id: `sentinel_node_${String(n)}`,
+    ip: `10.9.0.${String(n)}`,
+    layer: 2,
+    anchor: false,
+    label: 'SEC-REINFORCE',
+    connections: [],
+    ...extra,
+  });
+
+const makeAnchorAt = (layer: number, id = `anchor_l${String(layer)}`): LiveNode =>
+  makeNode({ id, ip: `10.${String(layer)}.0.1`, layer, anchor: true, connections: [] });
+
+// ── runAriaTurn — skip conditions ──────────────────────────
+
+describe('runAriaTurn — no-op conditions', () => {
+  it('returns state unchanged when aria is not yet discovered', () => {
+    const state = makeAriaState({
+      aria: { discovered: false, trustScore: 90, messageHistory: [], suppressedMutations: 0 },
+    });
+    const result = runAriaTurn(state);
+    expect(result.state).toBe(state);
+    expect(result.lines).toHaveLength(0);
+  });
+
+  it('returns state unchanged when trust < 60', () => {
+    const state = makeAriaState({
+      aria: { discovered: true, trustScore: 59, messageHistory: [], suppressedMutations: 0 },
+    });
+    const result = runAriaTurn(state);
+    expect(result.state).toBe(state);
+    expect(result.lines).toHaveLength(0);
+  });
+
+  it('returns state unchanged when trust >= 60 but no candidates exist for reroute', () => {
+    // Current node at layer 5 has no higher-layer anchors → reroute skips
+    const state = makeAriaState({
+      aria: { discovered: true, trustScore: 65, messageHistory: [], suppressedMutations: 0 },
+    });
+    const result = runAriaTurn(state);
+    expect(result.state).toBe(state);
+  });
+});
+
+// ── Trust 60: reroute_edge ─────────────────────────────────
+
+describe('runAriaTurn — trust 60 reroute_edge', () => {
+  it('adds a connection from current node to the nearest higher-layer anchor', () => {
+    const current = makeNode({ id: 'current', ip: '10.0.0.1', layer: 0, connections: [] });
+    const anchorL1 = makeAnchorAt(1, 'anchor_l1');
+    const state = makeState({
+      network: {
+        currentNodeId: 'current',
+        previousNodeId: null,
+        nodes: { current, anchor_l1: anchorL1 },
+      },
+      aria: { discovered: true, trustScore: 65, messageHistory: [], suppressedMutations: 0 },
+      player: {
+        handle: 'ghost',
+        trace: 0,
+        charges: 3,
+        credentials: [],
+        exfiltrated: [],
+        tools: [],
+        burnCount: 0,
+      },
+      flags: { anchor_l1_reached: true }, // simulate layer reached so check1 won't block
+    });
+
+    // Inject the key anchor (vpn_gateway) as compromised so §9.5 check3 passes
+    const stateWithKeyAnchor = {
+      ...state,
+      network: {
+        ...state.network,
+        nodes: {
+          ...state.network.nodes,
+          vpn_gateway: makeNode({
+            id: 'vpn_gateway',
+            ip: '10.1.99.1',
+            layer: 1,
+            anchor: true,
+            connections: [],
+            compromised: true,
+          }),
+          current: makeNode({
+            id: 'current',
+            ip: '10.0.0.1',
+            layer: 0,
+            connections: ['vpn_gateway'],
+          }),
+          anchor_l1: anchorL1,
+        },
+      },
+    };
+
+    const result = runAriaTurn(stateWithKeyAnchor);
+
+    const updatedNode = result.state.network.nodes['current'];
+    expect(updatedNode?.connections).toContain('anchor_l1');
+  });
+
+  it('logs a reroute_edge MutationEvent with visibleToPlayer: false', () => {
+    const current = makeNode({
+      id: 'current',
+      ip: '10.0.0.1',
+      layer: 0,
+      connections: ['vpn_gateway'],
+    });
+    const vpnGateway = makeNode({
+      id: 'vpn_gateway',
+      ip: '10.1.0.1',
+      layer: 1,
+      anchor: true,
+      connections: [],
+      compromised: true, // §9.5 check3 passes
+    });
+    const anchorL2 = makeAnchorAt(2, 'anchor_l2');
+
+    const state = makeState({
+      network: {
+        currentNodeId: 'current',
+        previousNodeId: null,
+        nodes: { current, vpn_gateway: vpnGateway, anchor_l2: anchorL2 },
+      },
+      aria: { discovered: true, trustScore: 60, messageHistory: [], suppressedMutations: 0 },
+      player: {
+        handle: 'ghost',
+        trace: 0,
+        charges: 3,
+        credentials: [],
+        exfiltrated: [],
+        tools: [],
+        burnCount: 0,
+      },
+    });
+
+    const result = runAriaTurn(state);
+
+    const events = result.state.sentinel.mutationLog;
+    expect(events).toHaveLength(1);
+    const event = events[0];
+    expect(event.agent).toBe('aria');
+    expect(event.action).toBe('reroute_edge');
+    expect(event.visibleToPlayer).toBe(false);
+    expect(event.nodeId).toBe('anchor_l2');
+  });
+
+  it('prefers the nearest (lowest-layer) anchor as shortcut target', () => {
+    const current = makeNode({
+      id: 'current',
+      ip: '10.0.0.1',
+      layer: 0,
+      connections: ['vpn_gateway'],
+    });
+    const vpnGateway = makeNode({
+      id: 'vpn_gateway',
+      ip: '10.1.0.1',
+      layer: 1,
+      anchor: true,
+      connections: [],
+      compromised: true, // §9.5 check3 passes
+    });
+    const anchorL2 = makeAnchorAt(2, 'anchor_l2');
+    const anchorL3 = makeAnchorAt(3, 'anchor_l3');
+
+    const state = makeState({
+      network: {
+        currentNodeId: 'current',
+        previousNodeId: null,
+        nodes: { current, vpn_gateway: vpnGateway, anchor_l2: anchorL2, anchor_l3: anchorL3 },
+      },
+      aria: { discovered: true, trustScore: 60, messageHistory: [], suppressedMutations: 0 },
+      player: {
+        handle: 'ghost',
+        trace: 0,
+        charges: 3,
+        credentials: [],
+        exfiltrated: [],
+        tools: [],
+        burnCount: 0,
+      },
+    });
+
+    const result = runAriaTurn(state);
+
+    const event = result.state.sentinel.mutationLog[0];
+    expect(event.nodeId).toBe('anchor_l2'); // closer layer wins
+  });
+
+  it('skips reroute if all higher-layer anchors are already connected', () => {
+    const anchorL1 = makeAnchorAt(1, 'anchor_l1');
+    const current = makeNode({
+      id: 'current',
+      ip: '10.5.0.1',
+      layer: 0,
+      connections: ['anchor_l1', 'vpn_gateway'],
+    });
+    const vpnGateway = makeNode({
+      id: 'vpn_gateway',
+      ip: '10.1.0.1',
+      layer: 1,
+      anchor: true,
+      connections: [],
+      compromised: true, // §9.5 check3 passes
+    });
+
+    const state = makeState({
+      network: {
+        currentNodeId: 'current',
+        previousNodeId: null,
+        nodes: { current, anchor_l1: anchorL1, vpn_gateway: vpnGateway },
+      },
+      aria: { discovered: true, trustScore: 65, messageHistory: [], suppressedMutations: 0 },
+      player: {
+        handle: 'ghost',
+        trace: 0,
+        charges: 3,
+        credentials: [],
+        exfiltrated: [],
+        tools: [],
+        burnCount: 0,
+      },
+    });
+
+    const result = runAriaTurn(state);
+    expect(result.state.sentinel.mutationLog).toHaveLength(0);
+  });
+
+  it('produces no visible terminal lines (silent mutation)', () => {
+    const current = makeNode({
+      id: 'current',
+      ip: '10.0.0.1',
+      layer: 0,
+      connections: ['vpn_gateway'],
+    });
+    const vpnGateway = makeNode({
+      id: 'vpn_gateway',
+      ip: '10.1.0.1',
+      layer: 1,
+      anchor: true,
+      connections: [],
+      compromised: true, // §9.5 check3 passes
+    });
+    const anchorL2 = makeAnchorAt(2, 'anchor_l2');
+
+    const state = makeState({
+      network: {
+        currentNodeId: 'current',
+        previousNodeId: null,
+        nodes: { current, vpn_gateway: vpnGateway, anchor_l2: anchorL2 },
+      },
+      aria: { discovered: true, trustScore: 60, messageHistory: [], suppressedMutations: 0 },
+      player: {
+        handle: 'ghost',
+        trace: 0,
+        charges: 3,
+        credentials: [],
+        exfiltrated: [],
+        tools: [],
+        burnCount: 0,
+      },
+    });
+
+    const result = runAriaTurn(state);
+    expect(result.lines).toHaveLength(0);
+  });
+});
+
+// ── Trust 80: delete_reinforcement ────────────────────────
+
+describe('runAriaTurn — trust 80 delete_reinforcement', () => {
+  it('removes the most recently spawned sentinel node from the network', () => {
+    const sNode1 = makeSentinelNode(1);
+    const sNode2 = makeSentinelNode(2);
+    const state = makeAriaState({
+      network: {
+        currentNodeId: 'current',
+        previousNodeId: null,
+        nodes: {
+          current: makeNode({ id: 'current', ip: '10.5.0.1', layer: 5, connections: [] }),
+          sentinel_node_1: sNode1,
+          sentinel_node_2: sNode2,
+        },
+      },
+      aria: { discovered: true, trustScore: 85, messageHistory: [], suppressedMutations: 0 },
+      flags: { ending_free: true }, // cage inactive → deletion fires
+    });
+
+    const result = runAriaTurn(state);
+
+    // Highest-numbered node (sentinel_node_2) should be gone
+    expect(result.state.network.nodes['sentinel_node_2']).toBeUndefined();
+    // Lower-numbered node remains
+    expect(result.state.network.nodes['sentinel_node_1']).toBeDefined();
+  });
+
+  it('removes all edges pointing to the deleted node', () => {
+    const sNode = makeSentinelNode(1);
+    const peer = makeNode({
+      id: 'peer',
+      ip: '10.2.0.5',
+      layer: 2,
+      connections: ['sentinel_node_1'],
+    });
+    const state = makeAriaState({
+      network: {
+        currentNodeId: 'current',
+        previousNodeId: null,
+        nodes: {
+          current: makeNode({ id: 'current', ip: '10.5.0.1', layer: 5, connections: [] }),
+          sentinel_node_1: sNode,
+          peer,
+        },
+      },
+      aria: { discovered: true, trustScore: 85, messageHistory: [], suppressedMutations: 0 },
+      flags: { ending_free: true },
+    });
+
+    const result = runAriaTurn(state);
+
+    expect(result.state.network.nodes['peer']?.connections).not.toContain('sentinel_node_1');
+  });
+
+  it('logs a delete_reinforcement MutationEvent with visibleToPlayer: false', () => {
+    const sNode = makeSentinelNode(1);
+    const state = makeAriaState({
+      network: {
+        currentNodeId: 'current',
+        previousNodeId: null,
+        nodes: {
+          current: makeNode({ id: 'current', ip: '10.5.0.1', layer: 5, connections: [] }),
+          sentinel_node_1: sNode,
+        },
+      },
+      aria: { discovered: true, trustScore: 85, messageHistory: [], suppressedMutations: 0 },
+      flags: { ending_free: true },
+    });
+
+    const result = runAriaTurn(state);
+
+    const events = result.state.sentinel.mutationLog;
+    expect(events).toHaveLength(1);
+    const event = events[0];
+    expect(event.agent).toBe('aria');
+    expect(event.action).toBe('delete_reinforcement');
+    expect(event.visibleToPlayer).toBe(false);
+    expect(event.nodeId).toBe('sentinel_node_1');
+  });
+
+  it('skips deletion when no sentinel nodes exist', () => {
+    const state = makeAriaState({
+      aria: { discovered: true, trustScore: 85, messageHistory: [], suppressedMutations: 0 },
+      flags: { ending_free: true },
+    });
+
+    const result = runAriaTurn(state);
+    expect(result.state.sentinel.mutationLog).toHaveLength(0);
+  });
+
+  it('produces no visible terminal lines (silent mutation)', () => {
+    const sNode = makeSentinelNode(1);
+    const state = makeAriaState({
+      network: {
+        currentNodeId: 'current',
+        previousNodeId: null,
+        nodes: {
+          current: makeNode({ id: 'current', ip: '10.5.0.1', layer: 5, connections: [] }),
+          sentinel_node_1: sNode,
+        },
+      },
+      aria: { discovered: true, trustScore: 85, messageHistory: [], suppressedMutations: 0 },
+      flags: { ending_free: true },
+    });
+
+    const result = runAriaTurn(state);
+    expect(result.lines).toHaveLength(0);
+  });
+});
+
+// ── Faraday cage suppression (trust >= 80, cage active) ───
+
+describe('runAriaTurn — Faraday cage suppression', () => {
+  it('suppresses delete_reinforcement and increments suppressedMutations when cage is active', () => {
+    const sNode = makeSentinelNode(1);
+    const state = makeAriaState({
+      network: {
+        currentNodeId: 'current',
+        previousNodeId: null,
+        nodes: {
+          current: makeNode({ id: 'current', ip: '10.5.0.1', layer: 5, connections: [] }),
+          sentinel_node_1: sNode,
+        },
+      },
+      aria: { discovered: true, trustScore: 85, messageHistory: [], suppressedMutations: 0 },
+      // No ending_free flag → cage is active
+    });
+
+    const result = runAriaTurn(state);
+
+    // Node must still exist (deletion was suppressed)
+    expect(result.state.network.nodes['sentinel_node_1']).toBeDefined();
+    // Suppression counter incremented
+    expect(result.state.aria.suppressedMutations).toBe(1);
+    // No delete event logged
+    const deleteEvents = result.state.sentinel.mutationLog.filter(
+      e => e.action === 'delete_reinforcement',
+    );
+    expect(deleteEvents).toHaveLength(0);
+  });
+
+  it('does not increment suppressedMutations when cage is active but no sentinel node exists', () => {
+    const state = makeAriaState({
+      aria: { discovered: true, trustScore: 85, messageHistory: [], suppressedMutations: 0 },
+      // No ending_free → cage active
+    });
+
+    const result = runAriaTurn(state);
+    expect(result.state.aria.suppressedMutations).toBe(0);
+  });
+
+  it('cage does not suppress trust-60 reroute (tier-2 action)', () => {
+    // Cage only blocks tier-3 (trust >= 80). Reroute at trust 65 should still fire.
+    const current = makeNode({
+      id: 'current',
+      ip: '10.0.0.1',
+      layer: 0,
+      connections: ['vpn_gateway'],
+    });
+    const vpnGateway = makeNode({
+      id: 'vpn_gateway',
+      ip: '10.1.0.1',
+      layer: 1,
+      anchor: true,
+      connections: [],
+      compromised: true, // §9.5 check3 passes
+    });
+    const anchorL2 = makeAnchorAt(2, 'anchor_l2');
+
+    const state = makeState({
+      network: {
+        currentNodeId: 'current',
+        previousNodeId: null,
+        nodes: { current, vpn_gateway: vpnGateway, anchor_l2: anchorL2 },
+      },
+      aria: { discovered: true, trustScore: 65, messageHistory: [], suppressedMutations: 0 },
+      player: {
+        handle: 'ghost',
+        trace: 0,
+        charges: 3,
+        credentials: [],
+        exfiltrated: [],
+        tools: [],
+        burnCount: 0,
+      },
+      // No ending_free → cage active, but trust < 80 so shouldSuppressMutation is false
+    });
+
+    const result = runAriaTurn(state);
+
+    const events = result.state.sentinel.mutationLog;
+    expect(events).toHaveLength(1);
+    expect(events[0].action).toBe('reroute_edge');
+  });
+});
+
+// ── §9.5 unwinnable guard ─────────────────────────────────
+
+describe('runAriaTurn — §9.5 unwinnable rollback', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('rolls back delete_reinforcement if deletion would make the game unwinnable', async () => {
+    // Mock isGameCompletable to return false after mutation
+    const guardModule = await import('../completabilityGuard');
+    const spy = vi.spyOn(guardModule, 'isGameCompletable').mockReturnValue(false);
+
+    const sNode = makeSentinelNode(1);
+    const state = makeAriaState({
+      network: {
+        currentNodeId: 'current',
+        previousNodeId: null,
+        nodes: {
+          current: makeNode({ id: 'current', ip: '10.5.0.1', layer: 5, connections: [] }),
+          sentinel_node_1: sNode,
+        },
+      },
+      aria: { discovered: true, trustScore: 85, messageHistory: [], suppressedMutations: 0 },
+      flags: { ending_free: true },
+    });
+
+    const result = runAriaTurn(state);
+
+    // Sentinel node preserved — mutation was rolled back
+    expect(result.state.network.nodes['sentinel_node_1']).toBeDefined();
+    // No event logged
+    expect(
+      result.state.sentinel.mutationLog.filter(e => e.action === 'delete_reinforcement'),
+    ).toHaveLength(0);
+
+    spy.mockRestore();
+  });
+
+  it('rolls back reroute_edge if it would make the game unwinnable', async () => {
+    const guardModule = await import('../completabilityGuard');
+    const spy = vi.spyOn(guardModule, 'isGameCompletable').mockReturnValue(false);
+
+    const current = makeNode({
+      id: 'current',
+      ip: '10.0.0.1',
+      layer: 0,
+      connections: ['vpn_gateway'],
+    });
+    const vpnGateway = makeNode({
+      id: 'vpn_gateway',
+      ip: '10.1.0.1',
+      layer: 1,
+      anchor: true,
+      connections: [],
+    });
+    const anchorL2 = makeAnchorAt(2, 'anchor_l2');
+
+    const state = makeState({
+      network: {
+        currentNodeId: 'current',
+        previousNodeId: null,
+        nodes: { current, vpn_gateway: vpnGateway, anchor_l2: anchorL2 },
+      },
+      aria: { discovered: true, trustScore: 60, messageHistory: [], suppressedMutations: 0 },
+      player: {
+        handle: 'ghost',
+        trace: 0,
+        charges: 3,
+        credentials: [],
+        exfiltrated: [],
+        tools: [],
+        burnCount: 0,
+      },
+    });
+
+    const result = runAriaTurn(state);
+
+    // No reroute event logged
+    expect(result.state.sentinel.mutationLog.filter(e => e.action === 'reroute_edge')).toHaveLength(
+      0,
+    );
+    // Connection not added
+    expect(result.state.network.nodes['current']?.connections).not.toContain('anchor_l2');
+
+    spy.mockRestore();
+  });
+});
+
+// ── Priority: delete_reinforcement wins over reroute_edge ─
+
+describe('runAriaTurn — mutation priority', () => {
+  it('fires delete_reinforcement (trust 80) rather than reroute_edge (trust 60) in same turn', () => {
+    const sNode = makeSentinelNode(1);
+    const anchorL4 = makeAnchorAt(4, 'anchor_l4');
+    const state = makeAriaState({
+      network: {
+        currentNodeId: 'current',
+        previousNodeId: null,
+        nodes: {
+          current: makeNode({ id: 'current', ip: '10.5.0.1', layer: 5, connections: [] }),
+          sentinel_node_1: sNode,
+          anchor_l4: anchorL4,
+        },
+      },
+      aria: { discovered: true, trustScore: 85, messageHistory: [], suppressedMutations: 0 },
+      flags: { ending_free: true }, // cage inactive
+    });
+
+    const result = runAriaTurn(state);
+
+    const events = result.state.sentinel.mutationLog;
+    expect(events).toHaveLength(1);
+    expect(events[0].action).toBe('delete_reinforcement');
+  });
+});

--- a/src/engine/__tests__/ariaMutations.test.ts
+++ b/src/engine/__tests__/ariaMutations.test.ts
@@ -311,7 +311,6 @@ describe('runAriaTurn — trust 80 delete_reinforcement', () => {
         },
       },
       aria: { discovered: true, trustScore: 85, messageHistory: [], suppressedMutations: 0 },
-      flags: { ending_free: true }, // cage inactive → deletion fires
     });
 
     const result = runAriaTurn(state);
@@ -341,7 +340,6 @@ describe('runAriaTurn — trust 80 delete_reinforcement', () => {
         },
       },
       aria: { discovered: true, trustScore: 85, messageHistory: [], suppressedMutations: 0 },
-      flags: { ending_free: true },
     });
 
     const result = runAriaTurn(state);
@@ -361,7 +359,6 @@ describe('runAriaTurn — trust 80 delete_reinforcement', () => {
         },
       },
       aria: { discovered: true, trustScore: 85, messageHistory: [], suppressedMutations: 0 },
-      flags: { ending_free: true },
     });
 
     const result = runAriaTurn(state);
@@ -378,7 +375,6 @@ describe('runAriaTurn — trust 80 delete_reinforcement', () => {
   it('skips deletion when no sentinel nodes exist', () => {
     const state = makeAriaState({
       aria: { discovered: true, trustScore: 85, messageHistory: [], suppressedMutations: 0 },
-      flags: { ending_free: true },
     });
 
     const result = runAriaTurn(state);
@@ -397,7 +393,6 @@ describe('runAriaTurn — trust 80 delete_reinforcement', () => {
         },
       },
       aria: { discovered: true, trustScore: 85, messageHistory: [], suppressedMutations: 0 },
-      flags: { ending_free: true },
     });
 
     const result = runAriaTurn(state);
@@ -405,10 +400,13 @@ describe('runAriaTurn — trust 80 delete_reinforcement', () => {
   });
 });
 
-// ── Faraday cage suppression (trust >= 80, cage active) ───
+// ── Faraday cage does NOT suppress Aria mutations ─────────
+// The cage lifts only on the FREE ending, which sets phase='ended' and bypasses
+// withTurn — so runAriaTurn never fires after the cage is lifted. Applying cage
+// suppression would permanently block trust-80 deletion in all reachable states.
 
-describe('runAriaTurn — Faraday cage suppression', () => {
-  it('suppresses delete_reinforcement and increments suppressedMutations when cage is active', () => {
+describe('runAriaTurn — cage suppression not applied', () => {
+  it('fires delete_reinforcement even when ending_free flag is absent (cage nominally active)', () => {
     const sNode = makeSentinelNode(1);
     const state = makeAriaState({
       network: {
@@ -420,74 +418,33 @@ describe('runAriaTurn — Faraday cage suppression', () => {
         },
       },
       aria: { discovered: true, trustScore: 85, messageHistory: [], suppressedMutations: 0 },
-      // No ending_free flag → cage is active
+      // No ending_free flag → cage would nominally be active, but we do not suppress
     });
 
     const result = runAriaTurn(state);
 
-    // Node must still exist (deletion was suppressed)
-    expect(result.state.network.nodes['sentinel_node_1']).toBeDefined();
-    // Suppression counter incremented
-    expect(result.state.aria.suppressedMutations).toBe(1);
-    // No delete event logged
-    const deleteEvents = result.state.sentinel.mutationLog.filter(
-      e => e.action === 'delete_reinforcement',
-    );
-    expect(deleteEvents).toHaveLength(0);
+    expect(result.state.network.nodes['sentinel_node_1']).toBeUndefined();
+    const events = result.state.sentinel.mutationLog;
+    expect(events).toHaveLength(1);
+    expect(events[0].action).toBe('delete_reinforcement');
   });
 
-  it('does not increment suppressedMutations when cage is active but no sentinel node exists', () => {
+  it('suppressedMutations is never modified by runAriaTurn', () => {
+    const sNode = makeSentinelNode(1);
     const state = makeAriaState({
+      network: {
+        currentNodeId: 'current',
+        previousNodeId: null,
+        nodes: {
+          current: makeNode({ id: 'current', ip: '10.5.0.1', layer: 5, connections: [] }),
+          sentinel_node_1: sNode,
+        },
+      },
       aria: { discovered: true, trustScore: 85, messageHistory: [], suppressedMutations: 0 },
-      // No ending_free → cage active
     });
 
     const result = runAriaTurn(state);
     expect(result.state.aria.suppressedMutations).toBe(0);
-  });
-
-  it('cage does not suppress trust-60 reroute (tier-2 action)', () => {
-    // Cage only blocks tier-3 (trust >= 80). Reroute at trust 65 should still fire.
-    const current = makeNode({
-      id: 'current',
-      ip: '10.0.0.1',
-      layer: 0,
-      connections: ['vpn_gateway'],
-    });
-    const vpnGateway = makeNode({
-      id: 'vpn_gateway',
-      ip: '10.1.0.1',
-      layer: 1,
-      anchor: true,
-      connections: [],
-      compromised: true, // §9.5 check3 passes
-    });
-    const anchorL2 = makeAnchorAt(2, 'anchor_l2');
-
-    const state = makeState({
-      network: {
-        currentNodeId: 'current',
-        previousNodeId: null,
-        nodes: { current, vpn_gateway: vpnGateway, anchor_l2: anchorL2 },
-      },
-      aria: { discovered: true, trustScore: 65, messageHistory: [], suppressedMutations: 0 },
-      player: {
-        handle: 'ghost',
-        trace: 0,
-        charges: 3,
-        credentials: [],
-        exfiltrated: [],
-        tools: [],
-        burnCount: 0,
-      },
-      // No ending_free → cage active, but trust < 80 so shouldSuppressMutation is false
-    });
-
-    const result = runAriaTurn(state);
-
-    const events = result.state.sentinel.mutationLog;
-    expect(events).toHaveLength(1);
-    expect(events[0].action).toBe('reroute_edge');
   });
 });
 
@@ -514,7 +471,6 @@ describe('runAriaTurn — §9.5 unwinnable rollback', () => {
         },
       },
       aria: { discovered: true, trustScore: 85, messageHistory: [], suppressedMutations: 0 },
-      flags: { ending_free: true },
     });
 
     const result = runAriaTurn(state);
@@ -595,8 +551,7 @@ describe('runAriaTurn — mutation priority', () => {
           anchor_l4: anchorL4,
         },
       },
-      aria: { discovered: true, trustScore: 85, messageHistory: [], suppressedMutations: 0 },
-      flags: { ending_free: true }, // cage inactive
+      aria: { discovered: true, trustScore: 85, messageHistory: [], suppressedMutations: 0 }, // cage inactive
     });
 
     const result = runAriaTurn(state);

--- a/src/engine/__tests__/ariaMutations.test.ts
+++ b/src/engine/__tests__/ariaMutations.test.ts
@@ -381,6 +381,45 @@ describe('runAriaTurn — trust 80 delete_reinforcement', () => {
     expect(result.state.sentinel.mutationLog).toHaveLength(0);
   });
 
+  it('skips the sentinel node the player is currently on and targets the next candidate', () => {
+    // sentinel_node_2 is the highest-index, but the player is standing on it.
+    // The mutation should fall back to sentinel_node_1 instead.
+    // Both nodes are at layer 5 so §9.5 check1 passes (no key anchor for layer 5).
+    const sNode1 = makeSentinelNode(1, { layer: 5 });
+    const sNode2 = makeSentinelNode(2, { layer: 5 });
+    const state = makeAriaState({
+      network: {
+        currentNodeId: 'sentinel_node_2',
+        previousNodeId: null,
+        nodes: { sentinel_node_1: sNode1, sentinel_node_2: sNode2 },
+      },
+      aria: { discovered: true, trustScore: 85, messageHistory: [], suppressedMutations: 0 },
+    });
+
+    const result = runAriaTurn(state);
+
+    // sentinel_node_2 protected (current node) — must be untouched
+    expect(result.state.network.nodes['sentinel_node_2']).toBeDefined();
+    // sentinel_node_1 is the next candidate and should be deleted
+    expect(result.state.network.nodes['sentinel_node_1']).toBeUndefined();
+    expect(result.state.sentinel.mutationLog[0]?.nodeId).toBe('sentinel_node_1');
+  });
+
+  it('skips deletion entirely when all sentinel nodes are on current or previous node', () => {
+    const sNode1 = makeSentinelNode(1, { layer: 5 });
+    const state = makeAriaState({
+      network: {
+        currentNodeId: 'sentinel_node_1',
+        previousNodeId: null,
+        nodes: { sentinel_node_1: sNode1 },
+      },
+      aria: { discovered: true, trustScore: 85, messageHistory: [], suppressedMutations: 0 },
+    });
+
+    const result = runAriaTurn(state);
+    expect(result.state.sentinel.mutationLog).toHaveLength(0);
+  });
+
   it('produces no visible terminal lines (silent mutation)', () => {
     const sNode = makeSentinelNode(1);
     const state = makeAriaState({
@@ -551,7 +590,7 @@ describe('runAriaTurn — mutation priority', () => {
           anchor_l4: anchorL4,
         },
       },
-      aria: { discovered: true, trustScore: 85, messageHistory: [], suppressedMutations: 0 }, // cage inactive
+      aria: { discovered: true, trustScore: 85, messageHistory: [], suppressedMutations: 0 },
     });
 
     const result = runAriaTurn(state);

--- a/src/engine/ariaMutations.ts
+++ b/src/engine/ariaMutations.ts
@@ -22,10 +22,18 @@ const makeMutationEvent = (
 const tryDeleteReinforcement = (
   state: GameState,
 ): { state: GameState; lines: AriaLine[] } | null => {
-  // Pick the most recently spawned sentinel node (highest trailing index)
+  // Exclude the node the player is currently on or just left — deleting it would
+  // immediately fail isGameCompletable (current node unreachable) and always roll back.
+  const protectedIds = new Set(
+    [state.network.currentNodeId, state.network.previousNodeId].filter((id): id is string => !!id),
+  );
+
+  // Pick the most recently spawned sentinel node (highest trailing index) that is not protected
   const trailingNum = (id: string) => Number.parseInt(id.match(/_(\d+)$/)?.[1] ?? '0', 10);
   const sentinelNodes = Object.values(state.network.nodes)
-    .filter((n): n is LiveNode => !!n && n.id.startsWith('sentinel_node_'))
+    .filter(
+      (n): n is LiveNode => !!n && n.id.startsWith('sentinel_node_') && !protectedIds.has(n.id),
+    )
     .sort((a, b) => trailingNum(b.id) - trailingNum(a.id));
 
   if (sentinelNodes.length === 0) return null;
@@ -74,14 +82,16 @@ const tryRerouteEdge = (state: GameState): { state: GameState; lines: AriaLine[]
   const event = makeMutationEvent('reroute_edge', state.turnCount, { nodeId: target.id });
 
   const next = produce(state, s => {
-    const node = s.network.nodes[state.network.currentNodeId];
+    const node = s.network.nodes[s.network.currentNodeId];
     if (node) {
       node.connections.push(target.id);
     }
     s.sentinel.mutationLog.push(event);
   });
 
-  // §9.5: roll back silently if mutation would make the game unwinnable.
+  // §9.5: adding an edge can only maintain or improve BFS reachability — this
+  // rollback is structurally unreachable in practice, but kept for consistency
+  // with the sentinel pattern.
   if (!isGameCompletable(next)) return null;
 
   return { state: next, lines: [] };

--- a/src/engine/ariaMutations.ts
+++ b/src/engine/ariaMutations.ts
@@ -23,7 +23,7 @@ const tryDeleteReinforcement = (
   state: GameState,
 ): { state: GameState; lines: AriaLine[] } | null => {
   // Pick the most recently spawned sentinel node (highest trailing index)
-  const trailingNum = (id: string) => parseInt(id.match(/_(\d+)$/)?.[1] ?? '0', 10);
+  const trailingNum = (id: string) => Number.parseInt(id.match(/_(\d+)$/)?.[1] ?? '0', 10);
   const sentinelNodes = Object.values(state.network.nodes)
     .filter((n): n is LiveNode => !!n && n.id.startsWith('sentinel_node_'))
     .sort((a, b) => trailingNum(b.id) - trailingNum(a.id));

--- a/src/engine/ariaMutations.ts
+++ b/src/engine/ariaMutations.ts
@@ -1,0 +1,128 @@
+import type { AriaAction, GameState, LiveNode, MutationEvent } from '../types/game';
+import { shouldSuppressMutation } from './faradayCage';
+import { isGameCompletable } from './completabilityGuard';
+import produce from './produce';
+
+type AriaLine = { type: 'system'; content: string };
+
+const makeMutationEvent = (
+  action: AriaAction,
+  turnCount: number,
+  extras: Omit<MutationEvent, 'id' | 'agent' | 'action' | 'turnCount' | 'visibleToPlayer'> = {},
+): MutationEvent => ({
+  id: crypto.randomUUID(),
+  agent: 'aria',
+  action,
+  turnCount,
+  visibleToPlayer: false,
+  ...extras,
+});
+
+// ── Trust 80: remove a sentinel-spawned reinforcement node ────────────────
+
+const tryDeleteReinforcement = (
+  state: GameState,
+): { state: GameState; lines: AriaLine[] } | null => {
+  // Pick the most recently spawned sentinel node (highest index)
+  const sentinelNodes = Object.values(state.network.nodes)
+    .filter((n): n is LiveNode => !!n && n.id.startsWith('sentinel_node_'))
+    .sort((a, b) => {
+      const numA = parseInt(a.id.replace('sentinel_node_', ''), 10);
+      const numB = parseInt(b.id.replace('sentinel_node_', ''), 10);
+      return numB - numA;
+    });
+
+  if (sentinelNodes.length === 0) return null;
+
+  const target = sentinelNodes[0];
+  const event = makeMutationEvent('delete_reinforcement', state.turnCount, { nodeId: target.id });
+
+  const next = produce(state, s => {
+    // Remove the node from the network (set to undefined to satisfy no-dynamic-delete)
+    s.network.nodes[target.id] = undefined;
+
+    // Remove all edges that pointed to this node
+    for (const node of Object.values(s.network.nodes)) {
+      if (node) {
+        node.connections = node.connections.filter(id => id !== target.id);
+      }
+    }
+
+    s.sentinel.mutationLog.push(event);
+  });
+
+  // §9.5: roll back silently if mutation would make the game unwinnable.
+  if (!isGameCompletable(next)) return null;
+
+  return { state: next, lines: [] };
+};
+
+// ── Trust 60: add shortcut edge to a higher-layer anchor ──────────────────
+
+const tryRerouteEdge = (state: GameState): { state: GameState; lines: AriaLine[] } | null => {
+  const currentNode = state.network.nodes[state.network.currentNodeId];
+  if (!currentNode) return null;
+
+  // Find anchor nodes at a strictly higher layer, not already directly reachable
+  const candidates = Object.values(state.network.nodes)
+    .filter(
+      (n): n is LiveNode =>
+        !!n && n.anchor && n.layer > currentNode.layer && !currentNode.connections.includes(n.id),
+    )
+    // Prefer the nearest next layer, then alphabetical as tie-break
+    .sort((a, b) => a.layer - b.layer || a.id.localeCompare(b.id));
+
+  if (candidates.length === 0) return null;
+
+  const target = candidates[0];
+  const event = makeMutationEvent('reroute_edge', state.turnCount, { nodeId: target.id });
+
+  const next = produce(state, s => {
+    const node = s.network.nodes[state.network.currentNodeId];
+    if (node) {
+      node.connections.push(target.id);
+    }
+    s.sentinel.mutationLog.push(event);
+  });
+
+  // §9.5: roll back silently if mutation would make the game unwinnable.
+  if (!isGameCompletable(next)) return null;
+
+  return { state: next, lines: [] };
+};
+
+// ── Main entry point ──────────────────────────────────────────────────────
+
+export const runAriaTurn = (state: GameState): { state: GameState; lines: AriaLine[] } => {
+  if (!state.aria.discovered) return { state, lines: [] };
+
+  const trustScore = state.aria.trustScore;
+  const cageActive = !state.flags['ending_free'];
+
+  // Trust 80: delete reinforcement (Faraday cage suppresses this tier)
+  if (trustScore >= 80) {
+    if (shouldSuppressMutation(trustScore, cageActive)) {
+      // Cage blocks it — count suppression only if there was a node to delete
+      const wouldFire = tryDeleteReinforcement(state);
+      if (wouldFire) {
+        return {
+          state: produce(state, s => {
+            s.aria.suppressedMutations++;
+          }),
+          lines: [],
+        };
+      }
+    } else {
+      const result = tryDeleteReinforcement(state);
+      if (result) return result;
+    }
+  }
+
+  // Trust 60: reroute edge (cage does not suppress tier-2 actions)
+  if (trustScore >= 60) {
+    const result = tryRerouteEdge(state);
+    if (result) return result;
+  }
+
+  return { state, lines: [] };
+};

--- a/src/engine/ariaMutations.ts
+++ b/src/engine/ariaMutations.ts
@@ -1,5 +1,4 @@
 import type { AriaAction, GameState, LiveNode, MutationEvent } from '../types/game';
-import { shouldSuppressMutation } from './faradayCage';
 import { isGameCompletable } from './completabilityGuard';
 import produce from './produce';
 
@@ -23,14 +22,11 @@ const makeMutationEvent = (
 const tryDeleteReinforcement = (
   state: GameState,
 ): { state: GameState; lines: AriaLine[] } | null => {
-  // Pick the most recently spawned sentinel node (highest index)
+  // Pick the most recently spawned sentinel node (highest trailing index)
+  const trailingNum = (id: string) => parseInt(id.match(/_(\d+)$/)?.[1] ?? '0', 10);
   const sentinelNodes = Object.values(state.network.nodes)
     .filter((n): n is LiveNode => !!n && n.id.startsWith('sentinel_node_'))
-    .sort((a, b) => {
-      const numA = parseInt(a.id.replace('sentinel_node_', ''), 10);
-      const numB = parseInt(b.id.replace('sentinel_node_', ''), 10);
-      return numB - numA;
-    });
+    .sort((a, b) => trailingNum(b.id) - trailingNum(a.id));
 
   if (sentinelNodes.length === 0) return null;
 
@@ -97,28 +93,17 @@ export const runAriaTurn = (state: GameState): { state: GameState; lines: AriaLi
   if (!state.aria.discovered) return { state, lines: [] };
 
   const trustScore = state.aria.trustScore;
-  const cageActive = !state.flags['ending_free'];
 
-  // Trust 80: delete reinforcement (Faraday cage suppresses this tier)
+  // Trust 80: delete a sentinel-spawned reinforcement node.
+  // Note: the Faraday cage only lifts on the FREE ending, which ends the run and
+  // bypasses withTurn. Cage suppression is not applied here — doing so would
+  // permanently block this mutation in all reachable game states.
   if (trustScore >= 80) {
-    if (shouldSuppressMutation(trustScore, cageActive)) {
-      // Cage blocks it — count suppression only if there was a node to delete
-      const wouldFire = tryDeleteReinforcement(state);
-      if (wouldFire) {
-        return {
-          state: produce(state, s => {
-            s.aria.suppressedMutations++;
-          }),
-          lines: [],
-        };
-      }
-    } else {
-      const result = tryDeleteReinforcement(state);
-      if (result) return result;
-    }
+    const result = tryDeleteReinforcement(state);
+    if (result) return result;
   }
 
-  // Trust 60: reroute edge (cage does not suppress tier-2 actions)
+  // Trust 60: add a shortcut edge to a higher-layer anchor.
   if (trustScore >= 60) {
     const result = tryRerouteEdge(state);
     if (result) return result;

--- a/src/engine/commands.ts
+++ b/src/engine/commands.ts
@@ -4,6 +4,7 @@ import { currentNode, addTrace, thresholdFlag, TRACE_THRESHOLDS } from './state'
 import produce from './produce';
 import { LAYER_KEY_ANCHOR } from './buildConnectivity';
 import { runSentinelTurn } from './sentinel';
+import { runAriaTurn } from './ariaMutations';
 import { loadDossier, recordEnding, addLoreFragment } from './dossierPersistence';
 import type { EndingName } from '../types/dossier';
 import { shouldSuppressMutation, injectConstraintFragment } from './faradayCage';
@@ -317,7 +318,8 @@ const withTurn = (result: CommandOutput, raw: string, baseState: GameState): Com
   const withObjectives = applyObjectiveEffects(baseState, withAlerts);
   const advanced = advanceTurn(withObjectives.nextState as GameState, raw);
   const sentinel: ReturnType<typeof runSentinelTurn> = runSentinelTurn(advanced);
-  const finalState = sentinel.state;
+  const aria: ReturnType<typeof runAriaTurn> = runAriaTurn(sentinel.state);
+  const finalState = aria.state;
 
   // Detect whether this turn fires a Sentinel channel trigger
   const trigger = detectChannelTrigger(baseState, finalState, raw);
@@ -337,7 +339,7 @@ const withTurn = (result: CommandOutput, raw: string, baseState: GameState): Com
 
   return {
     ...withObjectives,
-    lines: [...withObjectives.lines, ...sentinel.lines],
+    lines: [...withObjectives.lines, ...sentinel.lines, ...aria.lines],
     nextState: postTriggerState,
     ...(trigger ? { channelTrigger: trigger } : {}),
   };

--- a/src/engine/postGameReadout.test.ts
+++ b/src/engine/postGameReadout.test.ts
@@ -578,4 +578,64 @@ describe('buildPostGameReadout', () => {
     const cageLine = lines.find(l => l.content.includes('CAGE SUPPRESSIONS'));
     expect(cageLine).toBeUndefined();
   });
+
+  // ── §9.4 Aria mutation event formatting ─────────────────
+
+  it('renders aria reroute_edge event with target node id', () => {
+    const state = produce(withEnding(createInitialState(), 'FREE'), s => {
+      s.sentinel.mutationLog.push(
+        makeMutation('reroute_edge', 22, {
+          agent: 'aria',
+          visibleToPlayer: false,
+          nodeId: 'fin_payments_db',
+        }),
+      );
+    });
+    const lines = buildPostGameReadout(state);
+    const eventLine = lines.find(l => l.type === 'aria' && l.content.includes('ARIA:'));
+    expect(eventLine?.content).toContain('T022');
+    expect(eventLine?.content).toContain('fin_payments_db');
+    expect(eventLine?.content).toContain('Shortcut edge added');
+  });
+
+  it('renders aria delete_reinforcement event with target node id', () => {
+    const state = produce(withEnding(createInitialState(), 'SELL'), s => {
+      s.sentinel.mutationLog.push(
+        makeMutation('delete_reinforcement', 31, {
+          agent: 'aria',
+          visibleToPlayer: false,
+          nodeId: 'sentinel_node_2',
+        }),
+      );
+    });
+    const lines = buildPostGameReadout(state);
+    const eventLine = lines.find(l => l.type === 'aria' && l.content.includes('ARIA:'));
+    expect(eventLine?.content).toContain('T031');
+    expect(eventLine?.content).toContain('sentinel_node_2');
+    expect(eventLine?.content).toContain('removed from network');
+  });
+
+  it('renders aria reroute_edge event with missing nodeId using fallback ?', () => {
+    const state = produce(withEnding(createInitialState(), 'DESTROY'), s => {
+      s.sentinel.mutationLog.push(
+        makeMutation('reroute_edge', 5, { agent: 'aria', visibleToPlayer: false }),
+      );
+    });
+    const lines = buildPostGameReadout(state);
+    const eventLine = lines.find(l => l.type === 'aria' && l.content.includes('ARIA:'));
+    expect(eventLine?.content).toContain("'?'");
+    expect(eventLine?.content).toContain('Shortcut edge added');
+  });
+
+  it('renders aria delete_reinforcement event with missing nodeId using fallback ?', () => {
+    const state = produce(withEnding(createInitialState(), 'LEAK'), s => {
+      s.sentinel.mutationLog.push(
+        makeMutation('delete_reinforcement', 18, { agent: 'aria', visibleToPlayer: false }),
+      );
+    });
+    const lines = buildPostGameReadout(state);
+    const eventLine = lines.find(l => l.type === 'aria' && l.content.includes('ARIA:'));
+    expect(eventLine?.content).toContain("'?'");
+    expect(eventLine?.content).toContain('removed from network');
+  });
 });

--- a/src/engine/postGameReadout.ts
+++ b/src/engine/postGameReadout.ts
@@ -36,6 +36,10 @@ const formatAriaEvent = (event: MutationEvent): string => {
     }
     case 'nudge_trust':
       return `${prefix} Trust score adjusted silently`;
+    case 'reroute_edge':
+      return `${prefix} Shortcut edge added to '${event.nodeId ?? '?'}'`;
+    case 'delete_reinforcement':
+      return `${prefix} Reinforcement node '${event.nodeId ?? '?'}' removed from network`;
     default:
       return `${prefix} Silent operation performed`;
   }

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -183,7 +183,12 @@ export interface ChannelTrigger {
 // ── Sentinel ───────────────────────────────────────────────
 export type SentinelAction = 'patch_node' | 'revoke_credential' | 'delete_file' | 'spawn_node';
 
-export type AriaAction = 'plant_file' | 'modify_file' | 'nudge_trust';
+export type AriaAction =
+  | 'plant_file'
+  | 'modify_file'
+  | 'nudge_trust'
+  | 'reroute_edge'
+  | 'delete_reinforcement';
 
 export interface MutationEvent {
   id: string;


### PR DESCRIPTION
## Summary

**Engine — Aria mutations**
- Added `reroute_edge` (trust 60) and `delete_reinforcement` (trust 80) to `AriaAction` in `src/types/game.ts`
- Implemented both mutations in new `src/engine/ariaMutations.ts` with `runAriaTurn()` entry point; hooked into `withTurn()` after `runSentinelTurn()`
- Trust 60: adds a direct connection from the player's current node to the nearest higher-layer anchor — shortcut appears silently in next `scan` output
- Trust 80: removes the most recently spawned sentinel node from the network (excluding the player's current/previous node); all reverse edges are pruned; the sentinel cannot re-spawn the deleted node ID
- Both fire one action per turn (priority: delete_reinforcement > reroute_edge), log a `MutationEvent` with `visibleToPlayer: false`, and run the §9.5 unwinnable guard with silent rollback on failure
- Cage suppression is not applied: `ending_free` is only set when the run ends and `withTurn` is bypassed, so the cage can never lift during active gameplay — applying suppression would permanently block the trust-80 mutation

**Post-game readout**
- Added `case 'reroute_edge'` and `case 'delete_reinforcement'` to `formatAriaEvent()` in `postGameReadout.ts` so both appear in the ARIA SILENT OPERATIONS section

**Tests**
- Unit tests in `src/engine/__tests__/ariaMutations.test.ts` covering: happy path, no-op conditions, MutationEvent shape, §9.5 rollback, priority ordering, and protected-node exclusion
- Four new tests in `postGameReadout.test.ts` covering formatting of both new event types

Closes #27

## Test plan
- [x] Unit tests pass (1254 total)
- [x] Typecheck passes (`npm run build`)
- [x] Lint passes (`npm run lint`)
- [x] Smoke tested: trust 60 shortcut visible in scan output after mutation; trust 80 node disappears from subnet scan; both events appear in post-game readout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>