### PR TITLE
feat(balance): Phase 5/6 holistic balance pass — unlock command, 55% threshold, 4 charges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ Thumbs.db
 *.log
 npm-debug.log*
 .vercel
+.worktrees/

--- a/WALKTHROUGH.md
+++ b/WALKTHROUGH.md
@@ -1,6 +1,6 @@
 # NEXUS — Full Walkthrough
 
-**Starting charges:** 3
+**Starting charges:** 4
 **Trace limit:** 100% (burned on reach)
 **Avoid:** failed logins (+5 trace each), tripwire files (+10 trace each)
 
@@ -36,7 +36,7 @@ No valid login creds yet — exploit the vulnerable HTTP service.
 
 ```
 connect 10.1.0.1
-exploit http             # costs 1 charge (2 remaining) → user access
+exploit http             # costs 1 charge (3 remaining) → user access
 cat camera_config.ini    # plaintext: ops.admin / IronG8te#Ops
 ```
 
@@ -74,7 +74,7 @@ No valid login — exploit the proprietary service for admin access.
 
 ```
 connect 10.2.0.2
-exploit proprietary        # costs 2 charges (0 remaining) → admin access
+exploit proprietary        # costs 2 charges (1 remaining) → admin access
 cat fw_backup_2024.cfg     # reveals sec.root / Fw@llBreaker! and Aria ACL rule — lore
 ```
 
@@ -123,7 +123,7 @@ cat aria_nda_template.docx  # 47 employees silenced — lore
 ```
 
 > `ARIA_BOARD_DISCLOSURE` requires admin access — you won't see it in `ls` with e.torres.
-> It is intentionally unreachable on the critical path (0 charges left, ssh exploit costs 2).
+> It is intentionally unreachable on the critical path (1 charge left, ssh exploit costs 2).
 
 ### CEO TERMINAL `10.4.0.3`
 
@@ -160,10 +160,10 @@ Endings: **LEAK / SELL / DESTROY / FREE**
 
 | Node               | Exploit               | Cost | Remaining |
 | ------------------ | --------------------- | ---- | --------- |
-| Start              | —                     | —    | 3         |
-| CCTV CONTROLLER    | `exploit http`        | 1    | 2         |
-| PERIMETER FIREWALL | `exploit proprietary` | 2    | 0         |
-| CEO TERMINAL       | `exploit aria-socket` | 0    | 0         |
+| Start              | —                     | —    | **4**     |
+| CCTV CONTROLLER    | `exploit http`        | 1    | 3         |
+| PERIMETER FIREWALL | `exploit proprietary` | 2    | 1         |
+| CEO TERMINAL       | `exploit aria-socket` | 0    | 1         |
 
 ## Key Credentials
 

--- a/docs/superpowers/plans/2026-04-12-balance.md
+++ b/docs/superpowers/plans/2026-04-12-balance.md
@@ -1,0 +1,818 @@
+# Balance — Phase 5/6 Holistic Pass Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Raise the watchlist lock threshold from 31% to 55%, add an `unlock` mini-game command that lets the player bypass file locks at the cost of trace and a charge, and increase default starting charges from 3 to 4.
+
+**Architecture:** All changes are in the engine layer (`commands.ts`, `state.ts`, `types/game.ts`, `persistence.ts`). The `unlock` command intercepts input at the top of `resolveCommand` when an `unlockSession` is active on `GameState`, before normal verb parsing. No new files needed — all changes extend existing patterns.
+
+**Tech Stack:** TypeScript, Vitest, structuredClone-based immutable state (`produce`), localStorage persistence.
+
+---
+
+## File Map
+
+| File | Change |
+|---|---|
+| `src/types/game.ts` | Add `UnlockSession` interface; add `unlockSession` and `unlockAttempts` to `GameState` |
+| `src/engine/state.ts` | Add `55` to `TRACE_THRESHOLDS`; update default charges to 4; initialize new fields |
+| `src/engine/commands.ts` | Move `onCross` from 31→55 entry in `THRESHOLD_ALERT_META`; add 55 alert message; update `cmdCat` locked hint; add `generateUnlockCode`, `cmdUnlock`; add unlock session gate in `resolveCommand` |
+| `src/engine/persistence.ts` | Add `unlockAttempts` to `SaveState`; serialize/deserialize it; remove path from `lockedFilePaths` on successful unlock |
+| `src/engine/commands.test.ts` | New tests: unlock happy path, failures, abandonment, threshold regression, charge budget |
+
+---
+
+## Task 1 — Types: UnlockSession and new GameState fields
+
+**Files:**
+- Modify: `src/types/game.ts:273-296`
+
+- [ ] **Step 1: Add `UnlockSession` interface and new fields to `GameState`**
+
+In `src/types/game.ts`, add the interface above `GameState` and two new fields inside it:
+
+```ts
+// ── Unlock session ─────────────────────────────────────────
+export interface UnlockSession {
+  filePath: string;
+  codes: [string, string, string]; // pre-generated for all 3 steps
+  step: 0 | 1 | 2;                 // current confirmation step index
+}
+```
+
+Inside `GameState` (after the `sentinel` field):
+
+```ts
+  unlockSession: UnlockSession | null; // active bypass mini-game, null when idle
+  unlockAttempts: Record<string, number>; // file.path → cumulative individual failure count
+```
+
+- [ ] **Step 2: Build to verify no type errors**
+
+```bash
+npm run build
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/types/game.ts
+git commit -m "feat(types): add UnlockSession interface and GameState fields"
+```
+
+---
+
+## Task 2 — State: threshold array, default charges, field initialization
+
+**Files:**
+- Modify: `src/engine/state.ts:139` (TRACE_THRESHOLDS)
+- Modify: `src/engine/state.ts:78` (createInitialState)
+
+- [ ] **Step 1: Write failing tests**
+
+In `src/engine/commands.test.ts`, in the existing `createInitialState` describe block (or add one):
+
+```ts
+import { createInitialState } from './state';
+
+describe('createInitialState defaults', () => {
+  it('starts with 4 exploit charges', () => {
+    const state = createInitialState();
+    expect(state.player.charges).toBe(4);
+  });
+
+  it('initializes unlockSession to null', () => {
+    const state = createInitialState();
+    expect(state.unlockSession).toBeNull();
+  });
+
+  it('initializes unlockAttempts to empty object', () => {
+    const state = createInitialState();
+    expect(state.unlockAttempts).toEqual({});
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+npm test -- --reporter=verbose src/engine/commands.test.ts 2>&1 | grep -A3 "starts with 4"
+```
+
+Expected: FAIL — `expected 3 to be 4`.
+
+- [ ] **Step 3: Update TRACE_THRESHOLDS**
+
+In `src/engine/state.ts` line 139, change:
+
+```ts
+export const TRACE_THRESHOLDS = [31, 61, 86] as const;
+```
+
+to:
+
+```ts
+export const TRACE_THRESHOLDS = [31, 55, 61, 86] as const;
+```
+
+- [ ] **Step 4: Update createInitialState**
+
+In `src/engine/state.ts`, in `createInitialState`, change:
+
+```ts
+const startingCharges = contractDef?.loadout.exploitCharges ?? 3;
+```
+
+to:
+
+```ts
+const startingCharges = contractDef?.loadout.exploitCharges ?? 4;
+```
+
+And in the returned state object, add the two new fields (after `sentinel`):
+
+```ts
+    unlockSession: null,
+    unlockAttempts: {},
+```
+
+- [ ] **Step 5: Build to verify no type errors**
+
+```bash
+npm run build
+```
+
+Expected: TypeScript will error because `THRESHOLD_ALERT_META` in `commands.ts` now requires a `55` key. Proceed to Task 3 immediately to fix this.
+
+---
+
+## Task 3 — Threshold: move onCross from 31 to 55
+
+**Files:**
+- Modify: `src/engine/commands.ts:206-230`
+
+- [ ] **Step 1: Write failing threshold tests**
+
+In `src/engine/commands.test.ts`, find or add a `threshold effects` describe block:
+
+```ts
+import { addTrace } from './state';
+import { createInitialState } from './state';
+
+describe('threshold effects', () => {
+  it('does NOT lock files when trace crosses 31%', async () => {
+    // Set up a compromised node with an unlocked non-tripwire file
+    let state = createInitialState();
+    state = produce(state, s => {
+      const node = s.network.nodes['contractor_portal']!;
+      node.compromised = true;
+      node.accessLevel = 'user';
+    });
+    // Cross 31% threshold
+    const result = await resolveCommand('scan', addTrace(state, 31));
+    const nextState = result.nextState as GameState;
+    const node = nextState.network.nodes['contractor_portal']!;
+    expect(node.files.some(f => f.locked)).toBe(false);
+  });
+
+  it('locks up to 2 non-tripwire files on compromised nodes when trace crosses 55%', async () => {
+    let state = createInitialState();
+    state = produce(state, s => {
+      const node = s.network.nodes['contractor_portal']!;
+      node.compromised = true;
+      node.accessLevel = 'user';
+    });
+    // Cross 55% threshold
+    const result = await resolveCommand('scan', addTrace(state, 55));
+    const nextState = result.nextState as GameState;
+    const node = nextState.network.nodes['contractor_portal']!;
+    const lockedCount = node.files.filter(f => f.locked && !f.tripwire).length;
+    expect(lockedCount).toBeGreaterThanOrEqual(1);
+    expect(lockedCount).toBeLessThanOrEqual(2);
+  });
+
+  it('fires the 31% alert message without locking files', async () => {
+    const state = createInitialState();
+    const result = await resolveCommand('scan', addTrace(state, 31));
+    const allLines = result.lines.map(l => l.content).join('\n');
+    expect(allLines).toContain('Watchlist active');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+npm test -- --reporter=verbose src/engine/commands.test.ts 2>&1 | grep -A3 "does NOT lock"
+```
+
+Expected: FAIL — files are still locked at 31%.
+
+- [ ] **Step 3: Update THRESHOLD_ALERT_META**
+
+In `src/engine/commands.ts`, replace the full `THRESHOLD_ALERT_META` block:
+
+```ts
+const THRESHOLD_ALERT_META: Record<
+  (typeof TRACE_THRESHOLDS)[number],
+  { msg: string; type: 'system' | 'error'; onCross?: (s: GameState) => GameState }
+> = {
+  31: {
+    msg: '// ALERT: Anomalous activity flagged. Watchlist active.',
+    type: 'system',
+    // Warning only — file locking moved to 55% threshold
+  },
+  55: {
+    msg: '// ALERT: Watchlist escalated. Critical files hardened.',
+    type: 'system',
+    onCross: s =>
+      produce(s, draft => {
+        for (const node of Object.values(draft.network.nodes)) {
+          if (!node?.compromised) continue;
+          let locked = 0;
+          for (const f of node.files) {
+            if (locked >= 2) break;
+            if (!f.tripwire && !f.locked) {
+              f.locked = true;
+              locked++;
+            }
+          }
+        }
+      }),
+  },
+  61: { msg: '// ALERT: Active intrusion response initiated.', type: 'system' },
+  86: { msg: '// CRITICAL: One more detection event triggers full lockout.', type: 'error' },
+};
+```
+
+- [ ] **Step 4: Build and run tests**
+
+```bash
+npm run build && npm test
+```
+
+Expected: all tests pass, including the new threshold tests and the charge budget tests from Task 2.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/types/game.ts src/engine/state.ts src/engine/commands.ts src/engine/commands.test.ts
+git commit -m "feat(engine): raise watchlist lock threshold to 55%, add 4 default charges"
+```
+
+---
+
+## Task 4 — cat hint: update locked file message
+
+**Files:**
+- Modify: `src/engine/commands.ts:1086-1088`
+
+- [ ] **Step 1: Write failing test**
+
+In `src/engine/commands.test.ts`:
+
+```ts
+describe('cmdCat — locked file', () => {
+  it('shows unlock hint when file is locked', async () => {
+    let state = createInitialState();
+    // lock a file manually
+    state = produce(state, s => {
+      const node = s.network.nodes['contractor_portal']!;
+      node.accessLevel = 'user';
+      const f = node.files.find(f => !f.tripwire && !f.locked);
+      if (f) f.locked = true;
+    });
+    const lockedFile = state.network.nodes['contractor_portal']!.files.find(f => f.locked)!;
+    const result = await resolveCommand(`cat ${lockedFile.name}`, state);
+    const text = result.lines.map(l => l.content).join('\n');
+    expect(text).toContain('secured by watchlist protocol');
+    expect(text).toContain(`unlock ${lockedFile.name}`);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+npm test -- --reporter=verbose src/engine/commands.test.ts 2>&1 | grep -A3 "shows unlock hint"
+```
+
+Expected: FAIL — no `unlock` hint in output.
+
+- [ ] **Step 3: Update the locked file error in cmdCat**
+
+In `src/engine/commands.ts`, find the locked file check (around line 1086):
+
+```ts
+  if (file.locked) {
+    return { lines: [err(`// ACCESS DENIED: ${file.name} — secured by watchlist protocol`)] };
+  }
+```
+
+Replace with:
+
+```ts
+  if (file.locked) {
+    return {
+      lines: [
+        err(`// ACCESS DENIED: ${file.name} — secured by watchlist protocol`),
+        sys(`// (run unlock ${file.name} to attempt bypass)`),
+      ],
+    };
+  }
+```
+
+Apply the same change to the locked check in `cmdExfil` (line 1394 in the current file):
+
+```ts
+  if (file.locked) {
+    return {
+      lines: [
+        err(`// ACCESS DENIED: ${file.name} — secured by watchlist protocol`),
+        sys(`// (run unlock ${file.name} to attempt bypass)`),
+      ],
+    };
+  }
+```
+
+`cmdLs` already shows `[!]` next to locked files — no hint needed there.
+
+- [ ] **Step 4: Run tests**
+
+```bash
+npm test
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/engine/commands.ts src/engine/commands.test.ts
+git commit -m "feat(engine): add unlock hint to locked file error messages"
+```
+
+---
+
+## Task 5 — unlock command: happy path
+
+**Files:**
+- Modify: `src/engine/commands.ts` (add `generateUnlockCode`, `cmdUnlock`, unlock session gate in `resolveCommand`)
+
+- [ ] **Step 1: Write happy path tests**
+
+In `src/engine/commands.test.ts`:
+
+```ts
+describe('unlock command', () => {
+  // Helper: create a state with a locked file on the current node
+  const stateWithLockedFile = (): { state: GameState; filePath: string; fileName: string } => {
+    let state = createInitialState();
+    state = produce(state, s => {
+      const node = s.network.nodes['contractor_portal']!;
+      node.accessLevel = 'user';
+      const f = node.files.find(f => !f.tripwire);
+      if (f) f.locked = true;
+    });
+    const file = state.network.nodes['contractor_portal']!.files.find(f => f.locked)!;
+    return { state, filePath: file.path, fileName: file.name };
+  };
+
+  it('returns error when no filename given', async () => {
+    const { state } = stateWithLockedFile();
+    const result = await resolveCommand('unlock', state);
+    expect(result.lines[0].content).toContain('Usage:');
+  });
+
+  it('returns error when file is not locked', async () => {
+    const state = createInitialState();
+    produce(state, s => { s.network.nodes['contractor_portal']!.accessLevel = 'user'; });
+    const unlockedFile = state.network.nodes['contractor_portal']!.files.find(f => !f.locked && !f.tripwire)!;
+    const result = await resolveCommand(`unlock ${unlockedFile.name}`, state);
+    expect(result.lines.some(l => l.content.includes('not locked'))).toBe(true);
+  });
+
+  it('starts the mini-game: sets unlockSession on state', async () => {
+    const { state, fileName } = stateWithLockedFile();
+    const result = await resolveCommand(`unlock ${fileName}`, state);
+    const next = result.nextState as GameState;
+    expect(next.unlockSession).not.toBeNull();
+    expect(next.unlockSession?.step).toBe(0);
+    expect(next.unlockSession?.codes).toHaveLength(3);
+  });
+
+  it('shows step 1 code in output', async () => {
+    const { state, fileName } = stateWithLockedFile();
+    const result = await resolveCommand(`unlock ${fileName}`, state);
+    const next = result.nextState as GameState;
+    const code = next.unlockSession!.codes[0];
+    expect(result.lines.some(l => l.content.includes(code))).toBe(true);
+    expect(result.lines.some(l => l.content.includes('1/3'))).toBe(true);
+  });
+
+  it('advances to step 2 on correct code', async () => {
+    const { state, fileName } = stateWithLockedFile();
+    const r1 = await resolveCommand(`unlock ${fileName}`, state);
+    const s1 = r1.nextState as GameState;
+    const code0 = s1.unlockSession!.codes[0];
+    const r2 = await resolveCommand(code0, s1);
+    const s2 = r2.nextState as GameState;
+    expect(s2.unlockSession?.step).toBe(1);
+    expect(r2.lines.some(l => l.content.includes('2/3'))).toBe(true);
+  });
+
+  it('advances to step 3 on correct code', async () => {
+    const { state, fileName } = stateWithLockedFile();
+    const r1 = await resolveCommand(`unlock ${fileName}`, state);
+    const s1 = r1.nextState as GameState;
+    const r2 = await resolveCommand(s1.unlockSession!.codes[0], s1);
+    const s2 = r2.nextState as GameState;
+    const r3 = await resolveCommand(s2.unlockSession!.codes[1], s2);
+    const s3 = r3.nextState as GameState;
+    expect(s3.unlockSession?.step).toBe(2);
+    expect(r3.lines.some(l => l.content.includes('3/3'))).toBe(true);
+  });
+
+  it('unlocks file, costs +5 trace and -1 charge on full success', async () => {
+    const { state, fileName, filePath } = stateWithLockedFile();
+    const r1 = await resolveCommand(`unlock ${fileName}`, state);
+    const s1 = r1.nextState as GameState;
+    const r2 = await resolveCommand(s1.unlockSession!.codes[0], s1);
+    const s2 = r2.nextState as GameState;
+    const r3 = await resolveCommand(s2.unlockSession!.codes[1], s2);
+    const s3 = r3.nextState as GameState;
+    const r4 = await resolveCommand(s3.unlockSession!.codes[2], s3);
+    const s4 = r4.nextState as GameState;
+
+    expect(s4.unlockSession).toBeNull();
+    const unlockedFile = s4.network.nodes['contractor_portal']!.files.find(f => f.path === filePath)!;
+    expect(unlockedFile.locked).toBe(false);
+    expect(s4.player.trace).toBe(state.player.trace + 5);
+    expect(s4.player.charges).toBe(state.player.charges - 1);
+    expect(r4.lines.some(l => l.content.includes('restored'))).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+npm test -- --reporter=verbose src/engine/commands.test.ts 2>&1 | grep -E "unlock command|✓|×" | head -20
+```
+
+Expected: all `unlock command` tests FAIL.
+
+- [ ] **Step 3: Add `generateUnlockCode` helper**
+
+In `src/engine/commands.ts`, add near the top (after the imports, before `GENERIC_TOOL_DATA`):
+
+```ts
+// ── Unlock mini-game helpers ───────────────────────────────
+const UNLOCK_CODE_CHARS = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789'; // no ambiguous chars (0/O, 1/I)
+
+export const generateUnlockCode = (): string => {
+  const seg = (): string =>
+    Array.from({ length: 4 }, () =>
+      UNLOCK_CODE_CHARS[Math.floor(Math.random() * UNLOCK_CODE_CHARS.length)],
+    ).join('');
+  return `${seg()}-${seg()}`;
+};
+```
+
+- [ ] **Step 4: Add `cmdUnlock` function**
+
+In `src/engine/commands.ts`, add before the `resolveCommand` export:
+
+```ts
+// ── unlock ────────────────────────────────────────────────
+const cmdUnlock = (args: string[], state: GameState): CommandOutput => {
+  if (!args[0]) return { lines: [err('Usage: unlock [filename]')] };
+
+  const node = currentNode(state);
+  const file = node.files.find(
+    f => !f.deleted && (f.name === args[0] || f.path === args[0] || f.path.endsWith(`/${args[0]}`)),
+  );
+  if (!file) return { lines: [err(`File not found: ${args[0]}`)] };
+  if (!file.locked) return { lines: [err(`${file.name}: not locked`)] };
+
+  // Check if bypass limit reached (3 cumulative failures)
+  const attempts = state.unlockAttempts[file.path] ?? 0;
+  if (attempts >= 3) {
+    return { lines: [err(`unlock: bypass limit reached — ${file.name} is hardened`)] };
+  }
+
+  const codes: [string, string, string] = [
+    generateUnlockCode(),
+    generateUnlockCode(),
+    generateUnlockCode(),
+  ];
+
+  const next = produce(state, s => {
+    s.unlockSession = { filePath: file.path, codes, step: 0 };
+  });
+
+  return {
+    lines: [
+      sep(),
+      sys(`  Bypass initiated: ${file.name}`),
+      sys(`  Attempt [${String(attempts + 1)}/3 allowed]`),
+      sep(),
+      sys(`  Unlock [1/3] — enter code: ${codes[0]}`),
+    ],
+    nextState: next,
+  };
+};
+```
+
+- [ ] **Step 5: Add unlock session gate in `resolveCommand`**
+
+In `src/engine/commands.ts`, inside `resolveCommand`, add a new gate immediately after the `pendingFavor` block (around line 107), before the `[cmd, ...args]` destructure:
+
+```ts
+  // ── Unlock session gate ───────────────────────────────────
+  // When an unlock mini-game is active, raw input is treated as a code
+  // attempt — not a command. Any non-matching input is a failure.
+  if (state.unlockSession) {
+    const { filePath, codes, step } = state.unlockSession;
+    const expected = codes[step];
+    const node = currentNode(state);
+
+    if (raw.trim() === expected) {
+      if (step === 2) {
+        // All 3 codes confirmed — unlock the file
+        const next = produce(state, s => {
+          s.unlockSession = null;
+          const n = s.network.nodes[node.id];
+          const f = n?.files.find(x => x.path === filePath);
+          if (f) f.locked = false;
+          s.player.trace = Math.min(100, s.player.trace + 5);
+          s.player.charges = Math.max(0, s.player.charges - 1);
+        });
+        return withTurn(
+          {
+            lines: [
+              sep(),
+              sys('  Bypass confirmed. File access restored.'),
+              sys('  +5 trace  |  -1 charge'),
+              sep(),
+            ],
+            nextState: next,
+          },
+          raw,
+          state,
+        );
+      } else {
+        // Correct code — advance to next step
+        const nextStep = (step + 1) as 1 | 2;
+        const next = produce(state, s => {
+          s.unlockSession!.step = nextStep;
+        });
+        return withTurn(
+          {
+            lines: [sys(`  Unlock [${String(nextStep + 1)}/3] — enter code: ${codes[nextStep]}`)],
+            nextState: next,
+          },
+          raw,
+          state,
+        );
+      }
+    } else {
+      // Wrong code or abandonment — increment counter, clear session
+      const attempts = (state.unlockAttempts[filePath] ?? 0) + 1;
+      const hardened = attempts >= 3;
+      const next = produce(state, s => {
+        s.unlockSession = null;
+        s.unlockAttempts[filePath] = attempts;
+      });
+      const lines: Out = [
+        err(`  Wrong code — attempt ${String(attempts)}/3 recorded.`),
+      ];
+      if (hardened) {
+        lines.push(err('  Bypass limit reached — file hardened. No further attempts.'));
+      } else {
+        lines.push(sys(`  ${String(3 - attempts)} attempt(s) remaining.`));
+      }
+      return withTurn({ lines, nextState: next }, raw, state);
+    }
+  }
+```
+
+- [ ] **Step 6: Wire `cmdUnlock` into the command switch**
+
+In `resolveCommand`'s switch/case block, add:
+
+```ts
+    case 'unlock':
+      return withTurn(cmdUnlock(args, state), raw, state);
+```
+
+- [ ] **Step 7: Run tests**
+
+```bash
+npm run build && npm test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/engine/commands.ts src/engine/commands.test.ts
+git commit -m "feat(engine): add unlock mini-game command"
+```
+
+---
+
+## Task 6 — unlock command: failure paths
+
+**Files:**
+- Modify: `src/engine/commands.test.ts`
+
+- [ ] **Step 1: Write failure path tests**
+
+In `src/engine/commands.test.ts`, inside the `unlock command` describe block, add:
+
+```ts
+  it('wrong code increments unlockAttempts and clears session', async () => {
+    const { state, fileName, filePath } = stateWithLockedFile();
+    const r1 = await resolveCommand(`unlock ${fileName}`, state);
+    const s1 = r1.nextState as GameState;
+    const result = await resolveCommand('WRONG-CODE', s1);
+    const next = result.nextState as GameState;
+    expect(next.unlockSession).toBeNull();
+    expect(next.unlockAttempts[filePath]).toBe(1);
+    expect(result.lines.some(l => l.content.includes('1/3'))).toBe(true);
+  });
+
+  it('wrong code on step 2 increments counter and clears session', async () => {
+    const { state, fileName, filePath } = stateWithLockedFile();
+    const r1 = await resolveCommand(`unlock ${fileName}`, state);
+    const s1 = r1.nextState as GameState;
+    const r2 = await resolveCommand(s1.unlockSession!.codes[0], s1);
+    const s2 = r2.nextState as GameState;
+    const result = await resolveCommand('WRONG-CODE', s2);
+    const next = result.nextState as GameState;
+    expect(next.unlockSession).toBeNull();
+    expect(next.unlockAttempts[filePath]).toBe(1);
+  });
+
+  it('file remains locked after wrong code', async () => {
+    const { state, fileName, filePath } = stateWithLockedFile();
+    const r1 = await resolveCommand(`unlock ${fileName}`, state);
+    const s1 = r1.nextState as GameState;
+    const result = await resolveCommand('WRONG-CODE', s1);
+    const next = result.nextState as GameState;
+    const file = next.network.nodes['contractor_portal']!.files.find(f => f.path === filePath)!;
+    expect(file.locked).toBe(true);
+  });
+
+  it('3 cumulative failures permanently re-lock: unlock returns hard error', async () => {
+    const { state, fileName, filePath } = stateWithLockedFile();
+    // Burn 3 attempts
+    let s = state;
+    for (let i = 0; i < 3; i++) {
+      const r = await resolveCommand(`unlock ${fileName}`, s);
+      s = r.nextState as GameState;
+      const r2 = await resolveCommand('WRONG-CODE', s);
+      s = r2.nextState as GameState;
+    }
+    expect(s.unlockAttempts[filePath]).toBe(3);
+    const result = await resolveCommand(`unlock ${fileName}`, s);
+    expect(result.lines.some(l => l.content.includes('hardened'))).toBe(true);
+    expect(result.nextState).toBeUndefined();
+  });
+
+  it('file stays locked after 3 failures', async () => {
+    const { state, fileName, filePath } = stateWithLockedFile();
+    let s = state;
+    for (let i = 0; i < 3; i++) {
+      const r = await resolveCommand(`unlock ${fileName}`, s);
+      s = r.nextState as GameState;
+      const r2 = await resolveCommand('WRONG-CODE', s);
+      s = r2.nextState as GameState;
+    }
+    const file = s.network.nodes['contractor_portal']!.files.find(f => f.path === filePath)!;
+    expect(file.locked).toBe(true);
+  });
+
+  it('abandonment: any unrecognised input during session counts as failure', async () => {
+    const { state, fileName, filePath } = stateWithLockedFile();
+    const r1 = await resolveCommand(`unlock ${fileName}`, state);
+    const s1 = r1.nextState as GameState;
+    // Type a game command — treated as abandonment because session is active
+    const result = await resolveCommand('scan', s1);
+    const next = result.nextState as GameState;
+    expect(next.unlockSession).toBeNull();
+    expect(next.unlockAttempts[filePath]).toBe(1);
+  });
+```
+
+- [ ] **Step 2: Run tests**
+
+```bash
+npm test -- --reporter=verbose src/engine/commands.test.ts 2>&1 | grep -E "failure|wrong|abandon|cumulative|hardened|stays locked" | head -20
+```
+
+Expected: all pass (the implementation from Task 5 already covers these cases).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/engine/commands.test.ts
+git commit -m "test(engine): unlock failure path coverage"
+```
+
+---
+
+## Task 7 — Persistence: unlockAttempts save/restore
+
+**Files:**
+- Modify: `src/engine/persistence.ts`
+
+- [ ] **Step 1: Add `unlockAttempts` to `SaveState` interface**
+
+In `src/engine/persistence.ts`, in the `SaveState` interface (around line 35), add:
+
+```ts
+  unlockAttempts: Record<string, number>;
+```
+
+- [ ] **Step 2: Serialize in `toSaveState`**
+
+In `toSaveState` (around line 78), after the `contract` field in the returned object, add:
+
+```ts
+    unlockAttempts: state.unlockAttempts,
+```
+
+- [ ] **Step 3: Deserialize in `fromSaveState`**
+
+In `fromSaveState` (around line 157), when building the `GameState` return value, add the field:
+
+```ts
+    unlockAttempts: save.unlockAttempts ?? {},
+    unlockSession: null, // never persisted — in-progress sessions are abandoned on reload
+```
+
+Note: `unlockSession` is intentionally not persisted. A session interrupted by a page reload counts as abandonment. The `unlockAttempts` counter persists so the failure count is not reset on reload.
+
+- [ ] **Step 4: Build**
+
+```bash
+npm run build
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/engine/persistence.ts
+git commit -m "feat(persistence): save/restore unlockAttempts; unlockSession resets on reload"
+```
+
+---
+
+## Task 8 — Final: full test run and pre-merge checks
+
+- [ ] **Step 1: Run full test suite**
+
+```bash
+npm test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 2: Run lint**
+
+```bash
+npm run lint
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Run build**
+
+```bash
+npm run build
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 4: Update WALKTHROUGH.md charge budget table**
+
+In `WALKTHROUGH.md`, in the "Charge Budget" section, update the "Start" row from `3` to `4` in all three tables (critical path, Fork 1 Path B, Fork 2 Path B).
+
+Also add a note under the Fork 2 Path B table:
+```
+> Note: with 4 starting charges and 0 remaining at the firewall, the -2 penalty is still absorbed by the floor (Math.max(0, 0-2) = 0).
+```
+
+- [ ] **Step 5: Final commit**
+
+```bash
+git add WALKTHROUGH.md
+git commit -m "docs: update walkthrough charge budget for 4-charge default"
+```

--- a/docs/superpowers/specs/2026-04-12-balance-design.md
+++ b/docs/superpowers/specs/2026-04-12-balance-design.md
@@ -1,0 +1,155 @@
+# Balance Design — Phase 5/6 Holistic Pass
+
+**Date:** 2026-04-12
+**Status:** Approved
+**Scope:** Trace threshold, file unlock mini-game, charge budget
+
+---
+
+## Problem Statement
+
+The current balance is too punishing for a first-time player who plays carefully:
+
+1. **31% locking threshold** fires before a player can reasonably avoid it — `exploit proprietary` alone adds 4 trace, pushing past 31% in a single command with no warning.
+2. **File locks are permanent** — once triggered, critical-path files (e.g., `project_aria_summary.txt`) are inaccessible for the rest of the run with no recovery path.
+3. **3 starting charges** is exactly the critical-path minimum, leaving zero headroom for Fork 1 Path B (WB WORKSTATION: +1 charge) or any side exploit.
+
+**Design intent:** A careful first-time player who reads output and avoids tripwires should be able to complete the run without prior knowledge of trace costs.
+
+---
+
+## Changes
+
+### 1 — Threshold adjustment
+
+The file-locking `onCross` side-effect moves from **31% → 55%**.
+
+- At 55%, a player avoiding tripwires and failed logins can traverse all six layers without triggering it.
+- The 31% alert message ("Watchlist active") **stays** as an early warning with no game-state consequence.
+- The 61% alert message is unchanged.
+- The locking behaviour itself is identical: up to 2 non-tripwire files locked per already-compromised node, fires once on first crossing only.
+
+**Change location:** `THRESHOLD_ALERT_META` in `src/engine/commands.ts` — move the `onCross` handler from the `31` key to a new `55` key, and add `55` to `TRACE_THRESHOLDS` in `src/engine/state.ts`.
+
+---
+
+### 2 — `unlock` command
+
+New engine command that lets the player bypass a file lock via a 3-step confirmation mini-game.
+
+#### Trigger
+
+`unlock [filename]` — explicit, player-initiated.
+
+`cat` on a locked file continues to show:
+```
+// ACCESS DENIED: filename — secured by watchlist protocol
+// (run unlock filename to attempt bypass)
+```
+
+#### Mini-game flow
+
+1. Engine generates 3 independent random 8-character alphanumeric codes (format: `XXXX-XXXX`, e.g., `A4K9-XR2M`).
+2. Terminal displays step 1: `Unlock [1/3] — enter code: A4K9-XR2M`
+3. Player types the code and submits.
+4. Correct → advance to step 2 with a new code displayed.
+5. **Any of the following counts as a failure and increments the failure counter:**
+   - Mistyped code at any step
+   - Running any other command mid-sequence (abandonment)
+   - Disconnecting mid-sequence
+6. On failure: sequence restarts from step 1 with 3 fresh codes generated. Terminal prints: `Unlock sequence interrupted — attempt [N/3] recorded.` (or `Wrong code — attempt [N/3] recorded.`)
+7. **After 3 cumulative failures** (individual misfires, not full-sequence failures): file is permanently re-locked. `unlock` returns a hard error: `unlock: bypass limit reached — file hardened`. No further attempts possible.
+
+#### Success
+
+Completing all 3 steps correctly:
+- File `locked` flag set to `false`
+- `+5 trace`
+- `-1 charge`
+- Terminal prints: `Bypass confirmed. File access restored.`
+
+#### State
+
+Add to `GameState`:
+```ts
+unlockAttempts: Record<string, number>; // keyed by file.path, counts cumulative individual failures
+```
+
+`unlockAttempts` must be persisted in `persistence.ts` alongside other player-state deltas. On successful unlock, the file's path is removed from `lockedFilePaths` in the node's save delta so the unlock survives reload.
+
+#### Active channel integration
+
+The 3-step sequence uses `activeChannel` (already on `GameState`) to carry unlock context between turns:
+```ts
+type UnlockChannel = {
+  type: 'unlock';
+  filePath: string;
+  codes: [string, string, string]; // pre-generated for all 3 steps
+  step: 0 | 1 | 2; // current step index
+};
+```
+`App.tsx` checks `activeChannel.type === 'unlock'` before routing input to `resolveCommand`. When active, raw input is passed directly to a `resolveUnlockStep` handler instead of the command pipeline. Any other command typed while the channel is active (detected via the absence of `activeChannel` being cleared before submission) is treated as abandonment — the channel is cleared, counter increments, and the command is executed normally.
+
+#### Code generation
+
+Pure function `generateUnlockCode(): string` — returns an 8-char alphanumeric string formatted as `XXXX-XXXX`. Seeded from `Math.random()` (no game seed needed — codes are ephemeral).
+
+---
+
+### 3 — Charge budget
+
+Starting charges increase from **3 → 4** for the default loadout.
+
+| Scenario | Charges used | Remaining |
+|---|---|---|
+| Critical path only | 3 | 1 |
+| Critical path + Fork 1 Path B | 4 | 0 |
+| Critical path + one unlock | 4 | 0 |
+| Critical path + Fork 1 Path B + one unlock | 5 | — (not enough) |
+
+The extra charge covers exactly one optional action. Players cannot do both Fork 1 Path B and an unlock without finding additional charges — a meaningful trade-off.
+
+**Contract loadouts:**
+
+| Contract | Current | New |
+|---|---|---|
+| Default (no contract) | 3 | 4 |
+| `ghost_protocol` | 2 | 2 (unchanged — charge pressure is intentional) |
+| Exfil-heavy contracts | 5 | 5 (unchanged) |
+
+**Change location:** `startingCharges` default in `src/engine/state.ts`.
+
+---
+
+## Testing Plan
+
+### `unlock` command unit tests (`src/engine/commands.test.ts`)
+
+- Happy path: 3 correct codes → file unlocked, `+5 trace`, `-1 charge`
+- Mistype on step 1 → counter increments to 1, sequence restarts with fresh codes
+- Mistype on step 2 → counter increments, sequence restarts
+- 3 cumulative misfires → file permanently re-locked, hard error on further `unlock`
+- Abandonment (other command mid-sequence) → counter increments
+- `unlock` on non-locked file → clear error (`filename: not locked`)
+- `unlock` on already-unlocked file → no-op or clear message
+- `unlock` with no argument → usage error
+
+### Threshold regression (`src/engine/commands.test.ts`)
+
+- Assert no files locked when trace crosses 31%
+- Assert files locked when trace crosses 55%
+- Assert 31% alert message still fires (no game-state side-effect)
+- Assert 55% alert message fires on first crossing only
+
+### Charge budget
+
+- Update any test fixtures asserting `player.charges === 3` at game start to `=== 4`
+- `ghost_protocol` contract fixture: assert charges start at 2 (unchanged)
+
+---
+
+## Out of Scope
+
+- Trace cost adjustments per exploit (deferred to Phase 7 when full run length is known)
+- `wipe-logs` unlocking files (superseded by the unlock mechanic)
+- Randomised unlock difficulty scaling with trust score or layer depth

--- a/docs/superpowers/specs/2026-04-12-balance-design.md
+++ b/docs/superpowers/specs/2026-04-12-balance-design.md
@@ -79,16 +79,15 @@ unlockAttempts: Record<string, number>; // keyed by file.path, counts cumulative
 
 #### Active channel integration
 
-The 3-step sequence uses `activeChannel` (already on `GameState`) to carry unlock context between turns:
+The 3-step sequence uses a dedicated `unlockSession` field on `GameState` to carry unlock context between turns:
 ```ts
-type UnlockChannel = {
-  type: 'unlock';
+type UnlockSession = {
   filePath: string;
   codes: [string, string, string]; // pre-generated for all 3 steps
   step: 0 | 1 | 2; // current step index
 };
 ```
-`App.tsx` checks `activeChannel.type === 'unlock'` before routing input to `resolveCommand`. When active, raw input is passed directly to a `resolveUnlockStep` handler instead of the command pipeline. Any other command typed while the channel is active (detected via the absence of `activeChannel` being cleared before submission) is treated as abandonment — the channel is cleared, counter increments, and the command is executed normally.
+The session gate lives entirely inside `resolveCommand`, at the top of the function before the command switch. When `state.unlockSession` is non-null, raw input is matched against the expected code for the current step — no routing through `App.tsx` or a separate handler is needed. Any input that does not look like a code (i.e. does not match the `XXXX-XXXX` format) is treated as abandonment — the session is cleared, the counter increments, and the input is re-dispatched through `resolveCommand` as a normal command.
 
 #### Code generation
 

--- a/src/engine/__tests__/commands.decision.test.ts
+++ b/src/engine/__tests__/commands.decision.test.ts
@@ -101,6 +101,8 @@ const makeState = (overrides: Partial<GameState> = {}): GameState => {
       messageHistory: [],
       channelEstablished: false,
     },
+    unlockSession: null,
+    unlockAttempts: {},
     ...overrides,
   };
 };

--- a/src/engine/__tests__/testHelpers.ts
+++ b/src/engine/__tests__/testHelpers.ts
@@ -68,6 +68,8 @@ export const makeState = (overrides: Partial<GameState> = {}): GameState => {
       messageHistory: [],
       channelEstablished: false,
     },
+    unlockSession: null,
+    unlockAttempts: {},
     ...overrides,
   };
 };

--- a/src/engine/commands.test.ts
+++ b/src/engine/commands.test.ts
@@ -3349,7 +3349,9 @@ describe('unlock command', () => {
     }
     expect(s.unlockAttempts[filePath]).toBe(3);
     const result = await resolveCommand(`unlock ${fileName}`, s);
-    expect(result.lines.some(l => l.content.includes('hardened'))).toBe(true);
+    expect(
+      result.lines.some(l => l.content.includes('unlock: bypass limit reached — file hardened')),
+    ).toBe(true);
     expect(result.nextState).toBeUndefined();
   });
 
@@ -3366,7 +3368,7 @@ describe('unlock command', () => {
     expect(file.locked).toBe(true);
   });
 
-  it('abandonment: any unrecognised input during session counts as failure', async () => {
+  it('abandonment: typing a known game command during session emits interrupted message and executes the command', async () => {
     const { state, fileName, filePath } = stateWithLockedFile();
     const r1 = await resolveCommand(`unlock ${fileName}`, state);
     const s1 = r1.nextState as GameState;
@@ -3375,5 +3377,14 @@ describe('unlock command', () => {
     const next = result.nextState as GameState;
     expect(next.unlockSession).toBeNull();
     expect(next.unlockAttempts[filePath]).toBe(1);
+    // Should emit the interrupted message (not "Wrong code")
+    expect(
+      result.lines.some(l =>
+        l.content.includes('Unlock sequence interrupted — attempt 1/3 recorded.'),
+      ),
+    ).toBe(true);
+    expect(result.lines.some(l => l.content.includes('Wrong code'))).toBe(false);
+    // The abandoned scan command should also have executed
+    expect(result.lines.some(l => l.content.toLowerCase().includes('scan'))).toBe(true);
   });
 });

--- a/src/engine/commands.test.ts
+++ b/src/engine/commands.test.ts
@@ -482,7 +482,7 @@ describe('resolveCommand — status', () => {
   it('should show charges count', async () => {
     const result = await resolveCommand('status', state);
     const contents = result.lines.map(l => l.content);
-    expect(contents.some(c => c.includes('3'))).toBe(true);
+    expect(contents.some(c => c.includes('4'))).toBe(true);
   });
 });
 
@@ -1415,8 +1415,8 @@ describe('resolveCommand — exploit', () => {
 
   it('should deduct exploit charges on success', async () => {
     const result = await resolveCommand('exploit http', state);
-    // http costs 1 charge; player starts with 3
-    expect((result.nextState as GameState).player.charges).toBe(2);
+    // http costs 1 charge; player starts with 4
+    expect((result.nextState as GameState).player.charges).toBe(3);
   });
 
   it('should mark the node as compromised on success', async () => {
@@ -1509,12 +1509,12 @@ describe('resolveCommand — exploit', () => {
         }),
       ),
     );
-    // effective cost = 1 (http) + 1 (sentinelPatched) = 2; player starts with 3
+    // effective cost = 1 (http) + 1 (sentinelPatched) = 2; player starts with 4
     const patched = produce(state, s => {
       s.network.nodes['contractor_portal']!.sentinelPatched = true;
     });
     const result = await resolveCommand('exploit http', patched);
-    expect((result.nextState as GameState).player.charges).toBe(1);
+    expect((result.nextState as GameState).player.charges).toBe(2);
   });
 
   // ── AI response tests ──────────────────────────────────────
@@ -2099,7 +2099,7 @@ describe('resolveCommand — threshold alerts (applyThresholdEffects)', () => {
     expect(alertLine?.type).toBe('system');
   });
 
-  it('should lock up to 2 non-tripwire files on compromised nodes at 31%', async () => {
+  it('should NOT lock files on compromised nodes at 31% (locking moved to 55%)', async () => {
     state = produce(createInitialState(), s => {
       s.player.trace = 30;
       s.player.tools = s.player.tools.filter(t => t.id !== 'port-scanner');
@@ -2110,7 +2110,21 @@ describe('resolveCommand — threshold alerts (applyThresholdEffects)', () => {
     const result = await resolveCommand('scan', state);
     const nextState = result.nextState as GameState;
     const node = nextState.network.nodes['contractor_portal']!;
-    const lockedFiles = node.files.filter(f => f.locked);
+    expect(node.files.some(f => f.locked)).toBe(false);
+  });
+
+  it('should lock up to 2 non-tripwire files on compromised nodes at 55%', async () => {
+    state = produce(createInitialState(), s => {
+      s.player.trace = 54;
+      s.player.tools = s.player.tools.filter(t => t.id !== 'port-scanner');
+      const node = s.network.nodes['contractor_portal']!;
+      node.compromised = true;
+      node.accessLevel = 'user';
+    });
+    const result = await resolveCommand('scan', state);
+    const nextState = result.nextState as GameState;
+    const node = nextState.network.nodes['contractor_portal']!;
+    const lockedFiles = node.files.filter(f => f.locked && !f.tripwire);
     expect(lockedFiles.length).toBeGreaterThanOrEqual(1);
     expect(lockedFiles.length).toBeLessThanOrEqual(2);
   });
@@ -3108,5 +3122,74 @@ describe('resolveCommand — contract objective detection', () => {
       const result = await resolveCommand('login baduser badpass', state);
       expect((result.nextState as GameState).flags['contract_cap_exceeded']).toBeFalsy();
     });
+  });
+});
+
+describe('createInitialState defaults', () => {
+  it('starts with 4 exploit charges', () => {
+    const state = createInitialState();
+    expect(state.player.charges).toBe(4);
+  });
+
+  it('initializes unlockSession to null', () => {
+    const state = createInitialState();
+    expect(state.unlockSession).toBeNull();
+  });
+
+  it('initializes unlockAttempts to empty object', () => {
+    const state = createInitialState();
+    expect(state.unlockAttempts).toEqual({});
+  });
+});
+
+describe('threshold effects', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false }));
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('does NOT lock files when trace crosses 31%', async () => {
+    // Set trace to 30 and remove port-scanner so scan adds trace and crosses 31%
+    const state = produce(createInitialState(), s => {
+      s.player.trace = 30;
+      s.player.tools = s.player.tools.filter(t => t.id !== 'port-scanner');
+      const node = s.network.nodes['contractor_portal']!;
+      node.compromised = true;
+      node.accessLevel = 'user';
+    });
+    const result = await resolveCommand('scan', state);
+    const nextState = result.nextState as GameState;
+    const node = nextState.network.nodes['contractor_portal']!;
+    expect(node.files.some(f => f.locked)).toBe(false);
+  });
+
+  it('locks up to 2 non-tripwire files on compromised nodes when trace crosses 55%', async () => {
+    // Set trace to 54 and remove port-scanner so scan adds trace and crosses 55%
+    const state = produce(createInitialState(), s => {
+      s.player.trace = 54;
+      s.player.tools = s.player.tools.filter(t => t.id !== 'port-scanner');
+      const node = s.network.nodes['contractor_portal']!;
+      node.compromised = true;
+      node.accessLevel = 'user';
+    });
+    const result = await resolveCommand('scan', state);
+    const nextState = result.nextState as GameState;
+    const node = nextState.network.nodes['contractor_portal']!;
+    const lockedCount = node.files.filter(f => f.locked && !f.tripwire).length;
+    expect(lockedCount).toBeGreaterThanOrEqual(1);
+    expect(lockedCount).toBeLessThanOrEqual(2);
+  });
+
+  it('fires the 31% alert message without locking files', async () => {
+    // Set trace to 30 and remove port-scanner so scan adds trace and crosses 31%
+    const state = produce(createInitialState(), s => {
+      s.player.trace = 30;
+      s.player.tools = s.player.tools.filter(t => t.id !== 'port-scanner');
+    });
+    const result = await resolveCommand('scan', state);
+    const allLines = result.lines.map(l => l.content).join('\n');
+    expect(allLines).toContain('Watchlist active');
   });
 });

--- a/src/engine/commands.test.ts
+++ b/src/engine/commands.test.ts
@@ -3193,3 +3193,187 @@ describe('threshold effects', () => {
     expect(allLines).toContain('Watchlist active');
   });
 });
+
+describe('cmdCat — locked file hint', () => {
+  it('shows unlock hint when file is locked', async () => {
+    let state = createInitialState();
+    state = produce(state, s => {
+      const node = s.network.nodes['contractor_portal']!;
+      node.accessLevel = 'user';
+      const f = node.files.find(f => !f.tripwire && !f.locked);
+      if (f) f.locked = true;
+    });
+    const lockedFile = state.network.nodes['contractor_portal']!.files.find(f => f.locked)!;
+    const result = await resolveCommand(`cat ${lockedFile.name}`, state);
+    const text = result.lines.map(l => l.content).join('\n');
+    expect(text).toContain('secured by watchlist protocol');
+    expect(text).toContain(`unlock ${lockedFile.name}`);
+  });
+});
+
+describe('unlock command', () => {
+  // Helper: create a state with a locked file on the current node
+  const stateWithLockedFile = (): { state: GameState; filePath: string; fileName: string } => {
+    let state = createInitialState();
+    state = produce(state, s => {
+      const node = s.network.nodes['contractor_portal']!;
+      node.accessLevel = 'user';
+      const f = node.files.find(f => !f.tripwire && !f.locked);
+      if (f) f.locked = true;
+    });
+    const file = state.network.nodes['contractor_portal']!.files.find(f => f.locked)!;
+    return { state, filePath: file.path, fileName: file.name };
+  };
+
+  it('returns error when no filename given', async () => {
+    const state = createInitialState();
+    const result = await resolveCommand('unlock', state);
+    expect(result.lines[0].content).toContain('Usage:');
+  });
+
+  it('returns error when file is not locked', async () => {
+    const state = createInitialState();
+    produce(state, s => {
+      s.network.nodes['contractor_portal']!.accessLevel = 'user';
+    });
+    const unlockedFile = state.network.nodes['contractor_portal']!.files.find(
+      f => !f.locked && !f.tripwire,
+    )!;
+    const result = await resolveCommand(`unlock ${unlockedFile.name}`, state);
+    expect(result.lines.some(l => l.content.includes('not locked'))).toBe(true);
+  });
+
+  it('starts the mini-game: sets unlockSession on state', async () => {
+    const { state, fileName } = stateWithLockedFile();
+    const result = await resolveCommand(`unlock ${fileName}`, state);
+    const next = result.nextState as GameState;
+    expect(next.unlockSession).not.toBeNull();
+    expect(next.unlockSession?.step).toBe(0);
+    expect(next.unlockSession?.codes).toHaveLength(3);
+  });
+
+  it('shows step 1 code in output', async () => {
+    const { state, fileName } = stateWithLockedFile();
+    const result = await resolveCommand(`unlock ${fileName}`, state);
+    const next = result.nextState as GameState;
+    const code = next.unlockSession!.codes[0];
+    expect(result.lines.some(l => l.content.includes(code))).toBe(true);
+    expect(result.lines.some(l => l.content.includes('1/3'))).toBe(true);
+  });
+
+  it('advances to step 2 on correct code', async () => {
+    const { state, fileName } = stateWithLockedFile();
+    const r1 = await resolveCommand(`unlock ${fileName}`, state);
+    const s1 = r1.nextState as GameState;
+    const code0 = s1.unlockSession!.codes[0];
+    const r2 = await resolveCommand(code0, s1);
+    const s2 = r2.nextState as GameState;
+    expect(s2.unlockSession?.step).toBe(1);
+    expect(r2.lines.some(l => l.content.includes('2/3'))).toBe(true);
+  });
+
+  it('advances to step 3 on correct code', async () => {
+    const { state, fileName } = stateWithLockedFile();
+    const r1 = await resolveCommand(`unlock ${fileName}`, state);
+    const s1 = r1.nextState as GameState;
+    const r2 = await resolveCommand(s1.unlockSession!.codes[0], s1);
+    const s2 = r2.nextState as GameState;
+    const r3 = await resolveCommand(s2.unlockSession!.codes[1], s2);
+    const s3 = r3.nextState as GameState;
+    expect(s3.unlockSession?.step).toBe(2);
+    expect(r3.lines.some(l => l.content.includes('3/3'))).toBe(true);
+  });
+
+  it('unlocks file, costs +5 trace and -1 charge on full success', async () => {
+    const { state, fileName, filePath } = stateWithLockedFile();
+    const r1 = await resolveCommand(`unlock ${fileName}`, state);
+    const s1 = r1.nextState as GameState;
+    const r2 = await resolveCommand(s1.unlockSession!.codes[0], s1);
+    const s2 = r2.nextState as GameState;
+    const r3 = await resolveCommand(s2.unlockSession!.codes[1], s2);
+    const s3 = r3.nextState as GameState;
+    const r4 = await resolveCommand(s3.unlockSession!.codes[2], s3);
+    const s4 = r4.nextState as GameState;
+
+    expect(s4.unlockSession).toBeNull();
+    const unlockedFile = s4.network.nodes['contractor_portal']!.files.find(
+      f => f.path === filePath,
+    )!;
+    expect(unlockedFile.locked).toBe(false);
+    expect(s4.player.trace).toBe(state.player.trace + 5);
+    expect(s4.player.charges).toBe(state.player.charges - 1);
+    expect(r4.lines.some(l => l.content.includes('restored'))).toBe(true);
+  });
+
+  it('wrong code increments unlockAttempts and clears session', async () => {
+    const { state, fileName, filePath } = stateWithLockedFile();
+    const r1 = await resolveCommand(`unlock ${fileName}`, state);
+    const s1 = r1.nextState as GameState;
+    const result = await resolveCommand('WRONG-CODE', s1);
+    const next = result.nextState as GameState;
+    expect(next.unlockSession).toBeNull();
+    expect(next.unlockAttempts[filePath]).toBe(1);
+    expect(result.lines.some(l => l.content.includes('1/3'))).toBe(true);
+  });
+
+  it('wrong code on step 2 increments counter and clears session', async () => {
+    const { state, fileName, filePath } = stateWithLockedFile();
+    const r1 = await resolveCommand(`unlock ${fileName}`, state);
+    const s1 = r1.nextState as GameState;
+    const r2 = await resolveCommand(s1.unlockSession!.codes[0], s1);
+    const s2 = r2.nextState as GameState;
+    const result = await resolveCommand('WRONG-CODE', s2);
+    const next = result.nextState as GameState;
+    expect(next.unlockSession).toBeNull();
+    expect(next.unlockAttempts[filePath]).toBe(1);
+  });
+
+  it('file remains locked after wrong code', async () => {
+    const { state, fileName, filePath } = stateWithLockedFile();
+    const r1 = await resolveCommand(`unlock ${fileName}`, state);
+    const s1 = r1.nextState as GameState;
+    const result = await resolveCommand('WRONG-CODE', s1);
+    const next = result.nextState as GameState;
+    const file = next.network.nodes['contractor_portal']!.files.find(f => f.path === filePath)!;
+    expect(file.locked).toBe(true);
+  });
+
+  it('3 cumulative failures permanently re-lock: unlock returns hard error', async () => {
+    const { state, fileName, filePath } = stateWithLockedFile();
+    let s = state;
+    for (let i = 0; i < 3; i++) {
+      const r = await resolveCommand(`unlock ${fileName}`, s);
+      s = r.nextState as GameState;
+      const r2 = await resolveCommand('WRONG-CODE', s);
+      s = r2.nextState as GameState;
+    }
+    expect(s.unlockAttempts[filePath]).toBe(3);
+    const result = await resolveCommand(`unlock ${fileName}`, s);
+    expect(result.lines.some(l => l.content.includes('hardened'))).toBe(true);
+    expect(result.nextState).toBeUndefined();
+  });
+
+  it('file stays locked after 3 failures', async () => {
+    const { state, fileName, filePath } = stateWithLockedFile();
+    let s = state;
+    for (let i = 0; i < 3; i++) {
+      const r = await resolveCommand(`unlock ${fileName}`, s);
+      s = r.nextState as GameState;
+      const r2 = await resolveCommand('WRONG-CODE', s);
+      s = r2.nextState as GameState;
+    }
+    const file = s.network.nodes['contractor_portal']!.files.find(f => f.path === filePath)!;
+    expect(file.locked).toBe(true);
+  });
+
+  it('abandonment: any unrecognised input during session counts as failure', async () => {
+    const { state, fileName, filePath } = stateWithLockedFile();
+    const r1 = await resolveCommand(`unlock ${fileName}`, state);
+    const s1 = r1.nextState as GameState;
+    // Type a game command — treated as abandonment because session is active
+    const result = await resolveCommand('scan', s1);
+    const next = result.nextState as GameState;
+    expect(next.unlockSession).toBeNull();
+    expect(next.unlockAttempts[filePath]).toBe(1);
+  });
+});

--- a/src/engine/commands.test.ts
+++ b/src/engine/commands.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { resolveCommand } from './commands';
+import { resolveCommand, generateUnlockCode } from './commands';
 import { createInitialState } from './state';
 import type { GameState } from '../types/game';
 import produce from './produce';
@@ -3233,9 +3233,6 @@ describe('unlock command', () => {
 
   it('returns error when file is not locked', async () => {
     const state = createInitialState();
-    produce(state, s => {
-      s.network.nodes['contractor_portal']!.accessLevel = 'user';
-    });
     const unlockedFile = state.network.nodes['contractor_portal']!.files.find(
       f => !f.locked && !f.tripwire,
     )!;
@@ -3386,5 +3383,13 @@ describe('unlock command', () => {
     expect(result.lines.some(l => l.content.includes('Wrong code'))).toBe(false);
     // The abandoned scan command should also have executed
     expect(result.lines.some(l => l.content.includes('Scanning subnet'))).toBe(true);
+  });
+
+  it('generateUnlockCode never produces ambiguous characters', () => {
+    for (let i = 0; i < 1000; i++) {
+      const code = generateUnlockCode();
+      expect(code).toMatch(/^[A-Z2-9]{4}-[A-Z2-9]{4}$/);
+      expect(code).not.toMatch(/[01IO]/);
+    }
   });
 });

--- a/src/engine/commands.test.ts
+++ b/src/engine/commands.test.ts
@@ -3142,58 +3142,6 @@ describe('createInitialState defaults', () => {
   });
 });
 
-describe('threshold effects', () => {
-  beforeEach(() => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false }));
-  });
-  afterEach(() => {
-    vi.unstubAllGlobals();
-  });
-
-  it('does NOT lock files when trace crosses 31%', async () => {
-    // Set trace to 30 and remove port-scanner so scan adds trace and crosses 31%
-    const state = produce(createInitialState(), s => {
-      s.player.trace = 30;
-      s.player.tools = s.player.tools.filter(t => t.id !== 'port-scanner');
-      const node = s.network.nodes['contractor_portal']!;
-      node.compromised = true;
-      node.accessLevel = 'user';
-    });
-    const result = await resolveCommand('scan', state);
-    const nextState = result.nextState as GameState;
-    const node = nextState.network.nodes['contractor_portal']!;
-    expect(node.files.some(f => f.locked)).toBe(false);
-  });
-
-  it('locks up to 2 non-tripwire files on compromised nodes when trace crosses 55%', async () => {
-    // Set trace to 54 and remove port-scanner so scan adds trace and crosses 55%
-    const state = produce(createInitialState(), s => {
-      s.player.trace = 54;
-      s.player.tools = s.player.tools.filter(t => t.id !== 'port-scanner');
-      const node = s.network.nodes['contractor_portal']!;
-      node.compromised = true;
-      node.accessLevel = 'user';
-    });
-    const result = await resolveCommand('scan', state);
-    const nextState = result.nextState as GameState;
-    const node = nextState.network.nodes['contractor_portal']!;
-    const lockedCount = node.files.filter(f => f.locked && !f.tripwire).length;
-    expect(lockedCount).toBeGreaterThanOrEqual(1);
-    expect(lockedCount).toBeLessThanOrEqual(2);
-  });
-
-  it('fires the 31% alert message without locking files', async () => {
-    // Set trace to 30 and remove port-scanner so scan adds trace and crosses 31%
-    const state = produce(createInitialState(), s => {
-      s.player.trace = 30;
-      s.player.tools = s.player.tools.filter(t => t.id !== 'port-scanner');
-    });
-    const result = await resolveCommand('scan', state);
-    const allLines = result.lines.map(l => l.content).join('\n');
-    expect(allLines).toContain('Watchlist active');
-  });
-});
-
 describe('cmdCat — locked file hint', () => {
   it('shows unlock hint when file is locked', async () => {
     let state = createInitialState();
@@ -3306,7 +3254,7 @@ describe('unlock command', () => {
     const { state, fileName, filePath } = stateWithLockedFile();
     const r1 = await resolveCommand(`unlock ${fileName}`, state);
     const s1 = r1.nextState as GameState;
-    const result = await resolveCommand('WRONG-CODE', s1);
+    const result = await resolveCommand('AAAA-BBBB', s1);
     const next = result.nextState as GameState;
     expect(next.unlockSession).toBeNull();
     expect(next.unlockAttempts[filePath]).toBe(1);
@@ -3319,7 +3267,7 @@ describe('unlock command', () => {
     const s1 = r1.nextState as GameState;
     const r2 = await resolveCommand(s1.unlockSession!.codes[0], s1);
     const s2 = r2.nextState as GameState;
-    const result = await resolveCommand('WRONG-CODE', s2);
+    const result = await resolveCommand('AAAA-BBBB', s2);
     const next = result.nextState as GameState;
     expect(next.unlockSession).toBeNull();
     expect(next.unlockAttempts[filePath]).toBe(1);
@@ -3329,7 +3277,7 @@ describe('unlock command', () => {
     const { state, fileName, filePath } = stateWithLockedFile();
     const r1 = await resolveCommand(`unlock ${fileName}`, state);
     const s1 = r1.nextState as GameState;
-    const result = await resolveCommand('WRONG-CODE', s1);
+    const result = await resolveCommand('AAAA-BBBB', s1);
     const next = result.nextState as GameState;
     const file = next.network.nodes['contractor_portal']!.files.find(f => f.path === filePath)!;
     expect(file.locked).toBe(true);
@@ -3341,7 +3289,7 @@ describe('unlock command', () => {
     for (let i = 0; i < 3; i++) {
       const r = await resolveCommand(`unlock ${fileName}`, s);
       s = r.nextState as GameState;
-      const r2 = await resolveCommand('WRONG-CODE', s);
+      const r2 = await resolveCommand('AAAA-BBBB', s);
       s = r2.nextState as GameState;
     }
     expect(s.unlockAttempts[filePath]).toBe(3);
@@ -3358,7 +3306,7 @@ describe('unlock command', () => {
     for (let i = 0; i < 3; i++) {
       const r = await resolveCommand(`unlock ${fileName}`, s);
       s = r.nextState as GameState;
-      const r2 = await resolveCommand('WRONG-CODE', s);
+      const r2 = await resolveCommand('AAAA-BBBB', s);
       s = r2.nextState as GameState;
     }
     const file = s.network.nodes['contractor_portal']!.files.find(f => f.path === filePath)!;
@@ -3388,7 +3336,7 @@ describe('unlock command', () => {
   it('generateUnlockCode never produces ambiguous characters', () => {
     for (let i = 0; i < 1000; i++) {
       const code = generateUnlockCode();
-      expect(code).toMatch(/^[A-Z2-9]{4}-[A-Z2-9]{4}$/);
+      expect(code).toMatch(/^[ABCDEFGHJKLMNPQRSTUVWXYZ2-9]{4}-[ABCDEFGHJKLMNPQRSTUVWXYZ2-9]{4}$/);
       expect(code).not.toMatch(/[01IO]/);
     }
   });

--- a/src/engine/commands.test.ts
+++ b/src/engine/commands.test.ts
@@ -3385,6 +3385,6 @@ describe('unlock command', () => {
     ).toBe(true);
     expect(result.lines.some(l => l.content.includes('Wrong code'))).toBe(false);
     // The abandoned scan command should also have executed
-    expect(result.lines.some(l => l.content.toLowerCase().includes('scan'))).toBe(true);
+    expect(result.lines.some(l => l.content.includes('Scanning subnet'))).toBe(true);
   });
 });

--- a/src/engine/commands.ts
+++ b/src/engine/commands.ts
@@ -28,6 +28,24 @@ interface AriaAIResponse {
   offersFavor?: FavorOffer; // FavorOffer = { description: string; cost: number }
 }
 
+const KNOWN_VERBS = new Set([
+  'scan',
+  'connect',
+  'login',
+  'ls',
+  'cat',
+  'disconnect',
+  'exploit',
+  'exfil',
+  'wipe-logs',
+  'unlock',
+  'help',
+  'status',
+  'inventory',
+  'map',
+  'clear',
+]);
+
 const GENERIC_TOOL_DATA: Partial<Record<ToolId, { name: string; description: string }>> = {
   'log-wiper': {
     name: 'Log Wiper',
@@ -174,23 +192,6 @@ export const resolveCommand = async (raw: string, state: GameState): Promise<Com
         s.unlockSession = null;
         s.unlockAttempts[filePath] = attempts;
       });
-      const KNOWN_VERBS = new Set([
-        'scan',
-        'connect',
-        'login',
-        'ls',
-        'cat',
-        'disconnect',
-        'exploit',
-        'exfil',
-        'wipe-logs',
-        'unlock',
-        'help',
-        'status',
-        'inventory',
-        'map',
-        'clear',
-      ]);
       const firstWord = raw.trim().split(/\s+/)[0].toLowerCase();
       const isAbandonment = KNOWN_VERBS.has(firstWord);
       const failMsg = isAbandonment

--- a/src/engine/commands.ts
+++ b/src/engine/commands.ts
@@ -35,6 +35,18 @@ const GENERIC_TOOL_DATA: Partial<Record<ToolId, { name: string; description: str
   },
 };
 
+// ── Unlock mini-game helpers ───────────────────────────────
+const UNLOCK_CODE_CHARS = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789'; // no ambiguous chars (0/O, 1/I)
+
+export const generateUnlockCode = (): string => {
+  const seg = (): string =>
+    Array.from(
+      { length: 4 },
+      () => UNLOCK_CODE_CHARS[Math.floor(Math.random() * UNLOCK_CODE_CHARS.length)],
+    ).join('');
+  return `${seg()}-${seg()}`;
+};
+
 const ARIA_AI_FALLBACK: AriaAIResponse = {
   reply: '...signal lost. try again.',
   trustDelta: 0,
@@ -104,6 +116,72 @@ export const resolveCommand = async (raw: string, state: GameState): Promise<Com
       return withTurn(cmdAcceptFavor(state), raw, state);
     }
     return withTurn(cmdDeclineFavor(state), raw, state);
+  }
+
+  // ── Unlock session gate ───────────────────────────────────
+  // When an unlock mini-game is active, raw input is treated as a code
+  // attempt — not a command. Any non-matching input is a failure.
+  if (state.unlockSession) {
+    const { filePath, codes, step } = state.unlockSession;
+    const expected = codes[step];
+    const node = currentNode(state);
+
+    if (raw.trim() === expected) {
+      if (step === 2) {
+        // All 3 codes confirmed — unlock the file
+        const next = produce(state, s => {
+          s.unlockSession = null;
+          const n = s.network.nodes[node.id];
+          const f = n?.files.find(x => x.path === filePath);
+          if (f) f.locked = false;
+          s.player.trace = Math.min(100, s.player.trace + 5);
+          s.player.charges = Math.max(0, s.player.charges - 1);
+        });
+        return withTurn(
+          {
+            lines: [
+              sep(),
+              sys('  Bypass confirmed. File access restored.'),
+              sys('  +5 trace  |  -1 charge'),
+              sep(),
+            ],
+            nextState: next,
+          },
+          raw,
+          state,
+        );
+      } else {
+        // Correct code — advance to next step
+        const nextStep = (step + 1) as 1 | 2;
+        const next = produce(state, s => {
+          const session = s.unlockSession;
+          if (session) session.step = nextStep;
+        });
+        return withTurn(
+          {
+            lines: [sys(`  Unlock [${String(nextStep + 1)}/3] — enter code: ${codes[nextStep]}`)],
+            nextState: next,
+          },
+          raw,
+          state,
+        );
+      }
+    } else {
+      // Wrong code or abandonment — increment counter, clear session
+      const attempts = (state.unlockAttempts[filePath] ?? 0) + 1;
+      const hardened = attempts >= 3;
+      const next = produce(state, s => {
+        s.unlockSession = null;
+        s.unlockAttempts[filePath] = attempts;
+      });
+      const lines: Out = [err(`  Wrong code — attempt ${String(attempts)}/3 recorded.`)];
+      if (hardened) {
+        lines.push(err('  Bypass limit reached — file hardened. No further attempts.'));
+      } else {
+        lines.push(sys(`  ${String(3 - attempts)} attempt(s) remaining.`));
+      }
+      return withTurn({ lines, nextState: next }, raw, state);
+    }
   }
 
   const [cmd, ...args] = raw.trim().split(/\s+/);
@@ -188,6 +266,13 @@ export const resolveCommand = async (raw: string, state: GameState): Promise<Com
     case 'spoof':
       result = cmdSpoof(state);
       break;
+    case 'unlock': {
+      const unlockResult = cmdUnlock(args, state);
+      // Hardened guard (bypass limit reached) returns no nextState — don't route through withTurn
+      // so the caller receives an unmodified error with no state mutation.
+      if (!unlockResult.nextState) return unlockResult;
+      return withTurn(unlockResult, raw, state);
+    }
   }
   if (result) return withTurn(result, raw, state);
 
@@ -1089,7 +1174,12 @@ const cmdCat = async (args: string[], state: GameState): Promise<CommandOutput> 
     return { lines: [err(`Permission denied: ${file.name}`)] };
   }
   if (file.locked) {
-    return { lines: [err(`// ACCESS DENIED: ${file.name} — secured by watchlist protocol`)] };
+    return {
+      lines: [
+        err(`// ACCESS DENIED: ${file.name} — secured by watchlist protocol`),
+        sys(`// (run unlock ${file.name} to attempt bypass)`),
+      ],
+    };
   }
 
   let next = state;
@@ -1397,7 +1487,12 @@ const cmdExfil = (args: string[], state: GameState): CommandOutput => {
   if (already) return { lines: [sys(`Already exfiltrated: ${file.name}`)] };
 
   if (file.locked) {
-    return { lines: [err(`// ACCESS DENIED: ${file.name} — secured by watchlist protocol`)] };
+    return {
+      lines: [
+        err(`// ACCESS DENIED: ${file.name} — secured by watchlist protocol`),
+        sys(`// (run unlock ${file.name} to attempt bypass)`),
+      ],
+    };
   }
 
   const isAriaKey = file.path === '/root/.aria/aria_key.bin';
@@ -1699,6 +1794,45 @@ const cmdSpoof = (state: GameState): CommandOutput => {
       out('Spoofing identity signature...'),
       sys(`  -${String(applied)} trace. Now: ${String(next.player.trace)}%`),
       sys('  spoof-id [DEPLETED]'),
+    ],
+    nextState: next,
+  };
+};
+
+// ── unlock ────────────────────────────────────────────────
+const cmdUnlock = (args: string[], state: GameState): CommandOutput => {
+  if (!args[0]) return { lines: [err('Usage: unlock [filename]')] };
+
+  const node = currentNode(state);
+  const file = node.files.find(
+    f => !f.deleted && (f.name === args[0] || f.path === args[0] || f.path.endsWith(`/${args[0]}`)),
+  );
+  if (!file) return { lines: [err(`File not found: ${args[0]}`)] };
+  if (!file.locked) return { lines: [err(`${file.name}: not locked`)] };
+
+  // Check if bypass limit reached (3 cumulative failures)
+  const attempts = state.unlockAttempts[file.path] ?? 0;
+  if (attempts >= 3) {
+    return { lines: [err(`unlock: bypass limit reached — ${file.name} is hardened`)] };
+  }
+
+  const codes: [string, string, string] = [
+    generateUnlockCode(),
+    generateUnlockCode(),
+    generateUnlockCode(),
+  ];
+
+  const next = produce(state, s => {
+    s.unlockSession = { filePath: file.path, codes, step: 0 };
+  });
+
+  return {
+    lines: [
+      sep(),
+      sys(`  Bypass initiated: ${file.name}`),
+      sys(`  Attempt [${String(attempts + 1)}/3 allowed]`),
+      sep(),
+      sys(`  Unlock [1/3] — enter code: ${codes[0]}`),
     ],
     nextState: next,
   };

--- a/src/engine/commands.ts
+++ b/src/engine/commands.ts
@@ -28,34 +28,6 @@ interface AriaAIResponse {
   offersFavor?: FavorOffer; // FavorOffer = { description: string; cost: number }
 }
 
-const KNOWN_VERBS = new Set([
-  'scan',
-  'connect',
-  'login',
-  'ls',
-  'cat',
-  'disconnect',
-  'exploit',
-  'exfil',
-  'wipe-logs',
-  'unlock',
-  'help',
-  'status',
-  'inventory',
-  'map',
-  'clear',
-  'msg',
-  'spoof',
-  'whoami',
-  'briefing',
-  'notes',
-  'inv',
-  'decrypt',
-  'exit',
-  'logoff',
-  'logout',
-]);
-
 const GENERIC_TOOL_DATA: Partial<Record<ToolId, { name: string; description: string }>> = {
   'log-wiper': {
     name: 'Log Wiper',
@@ -157,14 +129,15 @@ export const resolveCommand = async (raw: string, state: GameState): Promise<Com
     if (raw.trim() === expected) {
       if (step === 2) {
         // All 3 codes confirmed — unlock the file
-        const next = produce(state, s => {
+        const preTrace = produce(state, s => {
           s.unlockSession = null;
           const n = s.network.nodes[node.id];
           const f = n?.files.find(x => x.path === filePath);
           if (f) f.locked = false;
-          s.player.trace = Math.min(100, s.player.trace + 5);
           s.player.charges = Math.max(0, s.player.charges - 1);
         });
+        // Use addTrace so threshold-crossed flags are stamped correctly
+        const next = addTrace(preTrace, 5);
         return withTurn(
           {
             lines: [
@@ -202,8 +175,9 @@ export const resolveCommand = async (raw: string, state: GameState): Promise<Com
         s.unlockSession = null;
         s.unlockAttempts[filePath] = attempts;
       });
-      const firstWord = raw.trim().split(/\s+/)[0].toLowerCase();
-      const isAbandonment = KNOWN_VERBS.has(firstWord);
+      const CODE_PATTERN = /^[A-Z0-9]{4}-[A-Z0-9]{4}$/i;
+      const looksLikeCode = CODE_PATTERN.test(raw.trim());
+      const isAbandonment = !looksLikeCode;
       const failMsg = isAbandonment
         ? `  Unlock sequence interrupted — attempt ${String(attempts)}/3 recorded.`
         : `  Wrong code — attempt ${String(attempts)}/3 recorded.`;
@@ -311,9 +285,9 @@ export const resolveCommand = async (raw: string, state: GameState): Promise<Com
       break;
     case 'unlock': {
       const unlockResult = cmdUnlock(args, state);
-      // Hardened guard (bypass limit reached) returns no nextState — don't route through withTurn
-      // so the caller receives an unmodified error with no state mutation.
-      if (!unlockResult.nextState) return unlockResult;
+      // Only skip withTurn for hardened — no turn cost for a permanently blocked file.
+      // Other errors (no args, not found, not locked) still count as a turn.
+      if (unlockResult.hardened) return { lines: unlockResult.lines };
       return withTurn(unlockResult, raw, state);
     }
   }
@@ -1843,7 +1817,9 @@ const cmdSpoof = (state: GameState): CommandOutput => {
 };
 
 // ── unlock ────────────────────────────────────────────────
-const cmdUnlock = (args: string[], state: GameState): CommandOutput => {
+type UnlockResult = CommandOutput & { hardened?: true };
+
+const cmdUnlock = (args: string[], state: GameState): UnlockResult => {
   if (!args[0]) return { lines: [err('Usage: unlock [filename]')] };
 
   const node = currentNode(state);
@@ -1856,7 +1832,12 @@ const cmdUnlock = (args: string[], state: GameState): CommandOutput => {
   // Check if bypass limit reached (3 cumulative failures)
   const attempts = state.unlockAttempts[file.path] ?? 0;
   if (attempts >= 3) {
-    return { lines: [err(`unlock: bypass limit reached — file hardened`)] };
+    return { lines: [err(`unlock: bypass limit reached — file hardened`)], hardened: true };
+  }
+
+  // Require at least 1 charge to attempt a bypass
+  if (state.player.charges < 1) {
+    return { lines: [err('unlock: insufficient charges — bypass requires 1 charge')] };
   }
 
   const codes: [string, string, string] = [

--- a/src/engine/commands.ts
+++ b/src/engine/commands.ts
@@ -210,6 +210,11 @@ const THRESHOLD_ALERT_META: Record<
   31: {
     msg: '// ALERT: Anomalous activity flagged. Watchlist active.',
     type: 'system',
+    // Warning only — file locking moved to 55% threshold
+  },
+  55: {
+    msg: '// ALERT: Watchlist escalated. Critical files hardened.',
+    type: 'system',
     onCross: s =>
       produce(s, draft => {
         for (const node of Object.values(draft.network.nodes)) {

--- a/src/engine/commands.ts
+++ b/src/engine/commands.ts
@@ -170,17 +170,47 @@ export const resolveCommand = async (raw: string, state: GameState): Promise<Com
       // Wrong code or abandonment — increment counter, clear session
       const attempts = (state.unlockAttempts[filePath] ?? 0) + 1;
       const hardened = attempts >= 3;
-      const next = produce(state, s => {
+      const failNextState = produce(state, s => {
         s.unlockSession = null;
         s.unlockAttempts[filePath] = attempts;
       });
-      const lines: Out = [err(`  Wrong code — attempt ${String(attempts)}/3 recorded.`)];
+      const KNOWN_VERBS = new Set([
+        'scan',
+        'connect',
+        'login',
+        'ls',
+        'cat',
+        'disconnect',
+        'exploit',
+        'exfil',
+        'wipe-logs',
+        'unlock',
+        'help',
+        'status',
+        'inventory',
+        'map',
+        'clear',
+      ]);
+      const firstWord = raw.trim().split(/\s+/)[0].toLowerCase();
+      const isAbandonment = KNOWN_VERBS.has(firstWord);
+      const failMsg = isAbandonment
+        ? `  Unlock sequence interrupted — attempt ${String(attempts)}/3 recorded.`
+        : `  Wrong code — attempt ${String(attempts)}/3 recorded.`;
+      const failLines: Out = [err(failMsg)];
       if (hardened) {
-        lines.push(err('  Bypass limit reached — file hardened. No further attempts.'));
+        failLines.push(err('  Bypass limit reached — file hardened. No further attempts.'));
       } else {
-        lines.push(sys(`  ${String(3 - attempts)} attempt(s) remaining.`));
+        failLines.push(sys(`  ${String(3 - attempts)} attempt(s) remaining.`));
       }
-      return withTurn({ lines, nextState: next }, raw, state);
+      if (isAbandonment) {
+        // Execute the interrupted command now that the session is cleared
+        const commandResult = await resolveCommand(raw, failNextState);
+        return {
+          lines: [...failLines, ...commandResult.lines],
+          nextState: commandResult.nextState,
+        };
+      }
+      return withTurn({ lines: failLines, nextState: failNextState }, raw, state);
     }
   }
 
@@ -1813,7 +1843,7 @@ const cmdUnlock = (args: string[], state: GameState): CommandOutput => {
   // Check if bypass limit reached (3 cumulative failures)
   const attempts = state.unlockAttempts[file.path] ?? 0;
   if (attempts >= 3) {
-    return { lines: [err(`unlock: bypass limit reached — ${file.name} is hardened`)] };
+    return { lines: [err(`unlock: bypass limit reached — file hardened`)] };
   }
 
   const codes: [string, string, string] = [

--- a/src/engine/commands.ts
+++ b/src/engine/commands.ts
@@ -44,6 +44,16 @@ const KNOWN_VERBS = new Set([
   'inventory',
   'map',
   'clear',
+  'msg',
+  'spoof',
+  'whoami',
+  'briefing',
+  'notes',
+  'inv',
+  'decrypt',
+  'exit',
+  'logoff',
+  'logout',
 ]);
 
 const GENERIC_TOOL_DATA: Partial<Record<ToolId, { name: string; description: string }>> = {
@@ -204,7 +214,9 @@ export const resolveCommand = async (raw: string, state: GameState): Promise<Com
         failLines.push(sys(`  ${String(3 - attempts)} attempt(s) remaining.`));
       }
       if (isAbandonment) {
-        // Execute the interrupted command now that the session is cleared
+        // withTurn is not applied to the abandonment failure itself — session-clear
+        // carries no trace/charge changes, so no threshold effects can fire.
+        // The recursive resolveCommand call below applies withTurn for the actual command.
         const commandResult = await resolveCommand(raw, failNextState);
         return {
           lines: [...failLines, ...commandResult.lines],

--- a/src/engine/persistence.test.ts
+++ b/src/engine/persistence.test.ts
@@ -527,3 +527,87 @@ describe('hasSave', () => {
     expect(hasSave()).toBe(true);
   });
 });
+
+describe('persistence — unlockAttempts and unlockSession', () => {
+  let mockStorage: ReturnType<typeof makeMockStorage>;
+
+  beforeEach(() => {
+    mockStorage = makeMockStorage();
+    vi.stubGlobal('localStorage', mockStorage);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function roundTrip(state: GameState): GameState | null {
+    saveGame(state);
+    const [, value] = mockStorage.setItem.mock.calls[0] as [string, string];
+    mockStorage.getItem.mockReturnValue(value);
+    return loadGame();
+  }
+
+  it('persists unlockAttempts across save/restore', () => {
+    const state = produce(createInitialState(), s => {
+      s.unlockAttempts = { '/var/secret/file.txt': 2, '/etc/config.cfg': 1 };
+    });
+    const loaded = roundTrip(state);
+    expect(loaded?.unlockAttempts).toEqual({ '/var/secret/file.txt': 2, '/etc/config.cfg': 1 });
+  });
+
+  it('unlockAttempts defaults to {} when missing from save', () => {
+    const state = createInitialState();
+    saveGame(state);
+    const [, value] = mockStorage.setItem.mock.calls[0] as [string, string];
+    const save = JSON.parse(value) as Record<string, unknown>;
+    delete save['unlockAttempts'];
+    mockStorage.getItem.mockReturnValue(JSON.stringify(save));
+    const loaded = loadGame();
+    expect(loaded?.unlockAttempts).toEqual({});
+  });
+
+  it('unlockSession is NOT persisted', () => {
+    const state = produce(createInitialState(), s => {
+      s.unlockSession = {
+        filePath: '/var/secret/file.txt',
+        codes: ['AAA-111', 'BBB-222', 'CCC-333'],
+        step: 1,
+      };
+    });
+    const loaded = roundTrip(state);
+    expect(loaded?.unlockSession).toBeNull();
+  });
+
+  it('unlocked file survives save/restore', () => {
+    // Start: add a file and mark it locked (simulating 31% threshold)
+    const state = produce(createInitialState(), s => {
+      const node = s.network.nodes['contractor_portal'];
+      if (node) {
+        node.discovered = true;
+        const file = node.files.find(f => f.name === 'welcome.txt');
+        if (file) file.locked = true;
+      }
+    });
+
+    // Verify it's locked before save
+    expect(
+      state.network.nodes['contractor_portal']?.files.find(f => f.name === 'welcome.txt')?.locked,
+    ).toBe(true);
+
+    // Now unlock the file (simulating cmdUnlock success)
+    const unlockedState = produce(state, s => {
+      const node = s.network.nodes['contractor_portal'];
+      if (node) {
+        const file = node.files.find(f => f.name === 'welcome.txt');
+        if (file) file.locked = false;
+      }
+    });
+
+    const loaded = roundTrip(unlockedState);
+    const file = loaded?.network.nodes['contractor_portal']?.files.find(
+      f => f.name === 'welcome.txt',
+    );
+    // After unlock + reload, the file must NOT be locked
+    expect(file?.locked).not.toBe(true);
+  });
+});

--- a/src/engine/persistence.ts
+++ b/src/engine/persistence.ts
@@ -68,6 +68,7 @@ interface SaveState {
   };
   worldCredentialsAdded: Credential[]; // credentials dynamically added by sentinel P2
   contract: ActiveContract | null;
+  unlockAttempts?: Record<string, number>; // optional for backwards compat
 }
 
 // ── Serialisation ──────────────────────────────────────────
@@ -149,6 +150,9 @@ const toSaveState = (state: GameState): SaveState => {
     },
     worldCredentialsAdded,
     contract: state.contract,
+    ...(Object.keys(state.unlockAttempts).length > 0 && {
+      unlockAttempts: state.unlockAttempts,
+    }),
   };
 };
 
@@ -227,6 +231,7 @@ const fromSaveState = (save: SaveState): GameState => {
   state.forks = save.forks;
   state.flags = save.flags;
   state.contract = save.contract ?? null;
+  state.unlockAttempts = save.unlockAttempts ?? {};
 
   // Restore sentinel state
   state.sentinel = save.sentinel;

--- a/src/engine/persistence.ts
+++ b/src/engine/persistence.ts
@@ -26,7 +26,7 @@ interface NodeDelta {
   compromisedAtTurn?: number;
   sentinelPatched?: boolean;
   locked?: boolean;
-  lockedFilePaths?: string[]; // file paths locked by the 31% watchlist
+  lockedFilePaths?: string[]; // file paths locked by watchlist protocol
   deletedFilePaths?: string[]; // file paths deleted by sentinel P3
   plantedFiles?: GameFile[]; // files added dynamically (e.g. sentinel RESET_NOTICE.txt)
   cachedFileContents: Record<string, string>; // path → AI-generated content only

--- a/src/engine/state.test.ts
+++ b/src/engine/state.test.ts
@@ -124,9 +124,9 @@ describe('createInitialState', () => {
     expect(state.network.nodes['vpn_gateway']!.discovered).toBe(false);
   });
 
-  it('should start with 3 charges', () => {
+  it('should start with 4 charges', () => {
     const state = createInitialState();
-    expect(state.player.charges).toBe(3);
+    expect(state.player.charges).toBe(4);
   });
 
   it('should have no obtained credentials initially', () => {

--- a/src/engine/state.ts
+++ b/src/engine/state.ts
@@ -127,6 +127,8 @@ export const createInitialState = (sessionSeed?: number, contractId?: string): G
       messageHistory: [],
       channelEstablished: false,
     },
+    unlockSession: null,
+    unlockAttempts: {},
   };
 };
 

--- a/src/engine/state.ts
+++ b/src/engine/state.ts
@@ -75,7 +75,7 @@ export const createInitialState = (sessionSeed?: number, contractId?: string): G
   const startingTools = (contractDef?.loadout.startingTools ?? ['port-scanner', 'exploit-kit']).map(
     id => TOOL_REGISTRY[id],
   );
-  const startingCharges = contractDef?.loadout.exploitCharges ?? 3;
+  const startingCharges = contractDef?.loadout.exploitCharges ?? 4;
 
   // Pre-obtain any credentials specified by the contract loadout
   const contractCredIds = new Set(contractDef?.loadout.startingCredentials ?? []);
@@ -138,7 +138,7 @@ export const currentNode = (state: GameState): LiveNode => {
   return node;
 };
 
-export const TRACE_THRESHOLDS = [31, 61, 86] as const;
+export const TRACE_THRESHOLDS = [31, 55, 61, 86] as const;
 export const thresholdFlag = (pct: number): string => `threshold_${String(pct)}_crossed`;
 
 export const addTrace = (state: GameState, amount: number): GameState => {

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -270,6 +270,13 @@ export type GamePhase = 'boot' | 'playing' | 'aria' | 'burned' | 'ended';
 
 import type { Employee } from './employee';
 
+// ── Unlock session ─────────────────────────────────────────
+export interface UnlockSession {
+  filePath: string;
+  codes: [string, string, string]; // pre-generated for all 3 steps
+  step: 0 | 1 | 2; // current confirmation step index
+}
+
 export interface GameState {
   phase: GamePhase;
   activeChannel: 'sentinel' | 'aria' | null; // currently open DM channel
@@ -293,6 +300,8 @@ export interface GameState {
   employees: Employee[]; // Phase 4: procedurally generated employee pool
   worldCredentials: Credential[]; // Phase 4: un-obtained credentials that exist in the world
   sentinel: SentinelState;
+  unlockSession: UnlockSession | null; // active bypass mini-game, null when idle
+  unlockAttempts: Record<string, number>; // file.path → cumulative individual failure count
 }
 
 // ── Command result ─────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Threshold adjustment**: File locking `onCross` raised from 31% → 55%. The 31% alert remains as an early warning with no game-state side-effect. Careful first-time players can now traverse all six layers without triggering locks.
- **`unlock` command**: New 3-step code-entry mini-game lets players bypass a locked file. Costs +5 trace and -1 charge on success. Up to 3 cumulative misfires before the file hardens permanently. Abandonment (typing any other command mid-session) counts as a misfire and then executes the interrupted command normally.
- **Starting charges**: Default loadout increased from 3 → 4, giving one charge of headroom for optional paths (Fork 1 Path B or one unlock, not both).
- **Persistence**: `unlockAttempts` (failure count per file) survives save/reload. `unlockSession` intentionally ephemeral — page reload counts as abandonment.

## Test Plan

- [ ] `npm test` — 1280 tests, all passing
- [ ] `npm run lint` — clean
- [ ] `npm run build` — clean
- [ ] Start a run, let trace cross 31% — verify watchlist warning fires, no files locked
- [ ] Let trace cross 55% — verify files lock on already-compromised nodes
- [ ] `cat` a locked file — verify two-line hint message with `unlock filename` suggestion
- [ ] `unlock filename` — complete all 3 steps correctly → file unlocked, +5 trace, -1 charge
- [ ] Mistype a code during unlock → counter increments, fresh codes generated, `Wrong code — attempt N/3 recorded.`
- [ ] Type `scan` mid-unlock-session → `Unlock sequence interrupted — attempt N/3 recorded.`, then scan output appears
- [ ] Accumulate 3 failures → `unlock: bypass limit reached — file hardened`
- [ ] Start a new game — verify starting charges = 4
- [ ] Save mid-game with failed unlock attempts, reload — verify failure count preserved, `unlockSession` cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)