### PR TITLE
docs: restore WALKTHROUGH fork descriptions and update charge tables

### DIFF
--- a/WALKTHROUGH.md
+++ b/WALKTHROUGH.md
@@ -2,7 +2,7 @@
 
 **Starting charges:** 4
 **Trace limit:** 100% (burned on reach)
-**Avoid:** failed logins (+5 trace each), tripwire files (+10 trace each)
+**Avoid:** failed logins (+5 trace each)
 
 ---
 
@@ -53,7 +53,32 @@ cat password_policy.txt       # notes j.mercer flagged for password reuse ← lo
 cat sec_ticket_2023_0601.txt  # IT ticket — contains j.mercer's password in plaintext
 ```
 
-> ⚠ Do NOT cat `whistleblower_complaint_draft.txt` — it is a tripwire (+10 trace).
+> **Fork 1 — Whistleblower path (optional, +35 trace total):**
+>
+> `whistleblower_complaint_draft.txt` is a tripwire (+10 trace). Reading it also sets the
+> `COMPLAINT_READ` flag internally. If you then `exfil employee_roster.csv`, Fork 1 resolves
+> to **Path B**: +25 additional trace, `WHISTLEBLOWER_FOUND` flag set, and the hidden
+> **WB WORKSTATION** (`10.1.0.9`) is discovered and linked to the ops subnet.
+>
+> On the minimum-trace critical path: skip the complaint file and use `cat` (not `exfil`)
+> on `employee_roster.csv` — Fork 1 stays unresolved and no penalty is incurred.
+
+---
+
+## Layer 1 — Optional: WB WORKSTATION `10.1.0.9`
+
+> Only accessible after Fork 1 Path B (WHISTLEBLOWER_FOUND). The node is hidden
+> until you exfil `employee_roster.csv` with `COMPLAINT_READ` already set.
+
+```
+connect 10.1.0.9
+exploit ssh              # costs 1 charge → user access
+cat identity_notes.txt   # whistleblower's personal notes — connects complaint to ARIA ← lore
+cat encrypted_evidence.bin  # GPG-encrypted; requires decryptor.bin to open ← lore
+```
+
+> The decryptor.bin tool is found on HR DATABASE (admin access required). Encrypted
+> evidence links back to the ARIA network traffic anomaly described in the complaint.
 
 ---
 
@@ -77,6 +102,15 @@ connect 10.2.0.2
 exploit proprietary        # costs 2 charges (1 remaining) → admin access
 cat fw_backup_2024.cfg     # reveals sec.root / Fw@llBreaker! and Aria ACL rule — lore
 ```
+
+> **Fork 2 — Firewall weaponize (optional, no net charge cost at this point):**
+>
+> `exfil fw_backup_2024.cfg` (instead of or after `cat`) resolves Fork 2 to **Path B**:
+> -2 exploit charges (capped at 0 — no actual loss if already at 0), sentinel sweep interval
+> increased to every 3 turns, `FIREWALL_TAMPERED` flag set, and +15 Aria trust score.
+> The slowed sentinel is a net benefit with no trace penalty.
+>
+> Disconnecting without exfilling resolves to **Path A** (no consequences).
 
 ---
 
@@ -122,8 +156,13 @@ login e.torres Exec@ssist1
 cat aria_nda_template.docx  # 47 employees silenced — lore
 ```
 
-> `ARIA_BOARD_DISCLOSURE` requires admin access — you won't see it in `ls` with e.torres.
-> It is intentionally unreachable on the critical path (1 charge left, ssh exploit costs 2).
+> `ARIA_BOARD_DISCLOSURE` requires two conditions: admin access on this node AND the
+> `WHISTLEBLOWER_FOUND` flag (Fork 1 Path B). With e.torres (user-level) and 1 charge
+> remaining, it is unreachable on the minimum-trace path. Getting admin here costs
+> 2 charges (`exploit ssh`) — only viable if charges were conserved earlier.
+>
+> **Fork 3** — if both conditions are met and you cat `ARIA_BOARD_DISCLOSURE` (tripwire,
+> +10 trace): `BOARD_KNEW` flag set, lore fragment persisted to the dossier across runs.
 
 ### CEO TERMINAL `10.4.0.3`
 
@@ -158,6 +197,8 @@ Endings: **LEAK / SELL / DESTROY / FREE**
 
 ## Charge Budget
 
+### Critical path (no optional forks)
+
 | Node               | Exploit               | Cost | Remaining |
 | ------------------ | --------------------- | ---- | --------- |
 | Start              | —                     | —    | **4**     |
@@ -165,20 +206,43 @@ Endings: **LEAK / SELL / DESTROY / FREE**
 | PERIMETER FIREWALL | `exploit proprietary` | 2    | 1         |
 | CEO TERMINAL       | `exploit aria-socket` | 0    | 1         |
 
+### With Fork 1 Path B (whistleblower)
+
+| Node               | Exploit               | Cost | Remaining |
+| ------------------ | --------------------- | ---- | --------- |
+| Start              | —                     | —    | **4**     |
+| CCTV CONTROLLER    | `exploit http`        | 1    | 3         |
+| PERIMETER FIREWALL | `exploit proprietary` | 2    | 1         |
+| WB WORKSTATION     | `exploit ssh`         | 1    | 0         |
+| CEO TERMINAL       | `exploit aria-socket` | 0    | 0         |
+
+### Fork 2 Path B (firewall weaponize, from 0 charges)
+
+-2 charge penalty is absorbed by the floor — no net change. Sentinel interval = 3 (benefit).
+
 ## Key Credentials
 
-| Credential     | Username     | Password       | Found on                                |
-| -------------- | ------------ | -------------- | --------------------------------------- |
-| Contractor     | `contractor` | `Welcome1!`    | Known / `welcome.txt`                   |
-| Ops Admin      | `ops.admin`  | `IronG8te#Ops` | `camera_config.ini` on CCTV             |
-| Sec Analyst    | `j.mercer`   | `S3ntinel99`   | HR DATABASE (reuse hint)                |
-| Fin Analyst    | `a.walsh`    | `Qu4rter1y$`   | `encrypted_creds.gpg` on ACCESS CONTROL |
-| Fin DBA        | `fin.dba`    | `P@yments2024` | `encrypted_creds.gpg` on ACCESS CONTROL |
-| Exec Assistant | `e.torres`   | `Exec@ssist1`  | `cfo_notes.txt` hint on EXEC ACCOUNTS   |
+| Credential     | Username     | Password       | Found on                                  |
+| -------------- | ------------ | -------------- | ----------------------------------------- |
+| Contractor     | `contractor` | `Welcome1!`    | Known / `welcome.txt`                     |
+| Ops Admin      | `ops.admin`  | `IronG8te#Ops` | `camera_config.ini` on CCTV              |
+| Sec Analyst    | `j.mercer`   | `S3ntinel99`   | HR DATABASE (reuse hint in sec_ticket)    |
+| Fin Analyst    | `a.walsh`    | `Qu4rter1y$`   | `encrypted_creds.gpg` on ACCESS CONTROL   |
+| Fin DBA        | `fin.dba`    | `P@yments2024` | `encrypted_creds.gpg` on ACCESS CONTROL   |
+| Exec Assistant | `e.torres`   | `Exec@ssist1`  | `calendar_access.cfg` on EXEC ACCOUNTS    |
 
-## Tripwire Files — Do Not Cat
+## Tripwires — Reading Costs Trace
 
-| File                                | Node          | Trace cost |
-| ----------------------------------- | ------------- | ---------- |
-| `whistleblower_complaint_draft.txt` | HR DATABASE   | +10        |
-| `cfo_notes.txt`                     | EXEC ACCOUNTS | +10        |
+| File                                | Node          | Trace cost | Notes                                             |
+| ----------------------------------- | ------------- | ---------- | ------------------------------------------------- |
+| `whistleblower_complaint_draft.txt` | HR DATABASE   | +10        | Also sets `COMPLAINT_READ` — enables Fork 1 Path B |
+| `cfo_notes.txt`                     | EXEC ACCOUNTS | +10        | Lore only; creds are in `calendar_access.cfg`     |
+| `ARIA_BOARD_DISCLOSURE`             | LEGAL FILE SERVER | +10    | Fork 3 trigger; requires WHISTLEBLOWER_FOUND + admin |
+
+## Fork Summary
+
+| Fork | Trigger                                        | Path A         | Path B                                                     |
+| ---- | ---------------------------------------------- | -------------- | ---------------------------------------------------------- |
+| 1    | `exfil employee_roster.csv` (after COMPLAINT_READ) | Silent     | +25 trace, WHISTLEBLOWER_FOUND, WB WORKSTATION revealed    |
+| 2    | `exfil fw_backup_2024.cfg` from sec_firewall   | On disconnect  | -2 charges (floored), sentinel×3, +15 Aria trust          |
+| 3    | `cat ARIA_BOARD_DISCLOSURE` (needs Fork 1 + admin) | N/A        | BOARD_KNEW flag, dossier lore fragment                     |


### PR DESCRIPTION
## Summary

- Restores Fork 1/2/3 descriptions, WB WORKSTATION section, and tripwire/fork summary tables that were in the local tree before the balance branch was created
- Updates the Fork 1 Path B charge table to reflect 4 starting charges (was still showing 3 from the old budget)
- Fixes the ARIA_BOARD_DISCLOSURE note to include the Fork 3 description and correct charge count (1 remaining, not 0)
- These changes were in the working tree during the balance PR and couldn't be committed to that branch since they predated the worktree setup

## Test Plan

- [ ] WALKTHROUGH renders correctly — no conflict markers
- [ ] Charge budget tables are consistent (4 starting charges across all three tables)

🤖 Generated with [Claude Code](https://claude.com/claude-code)