### PR TITLE
fix(engine): unlock correctness — CODE_PATTERN, charge guard, addTrace

### DIFF
--- a/src/engine/commands.test.ts
+++ b/src/engine/commands.test.ts
@@ -3342,14 +3342,17 @@ describe('unlock command', () => {
   });
 
   it('returns error when player has no charges', async () => {
-    const { state, fileName } = stateWithLockedFile();
+    const { state, fileName, filePath } = stateWithLockedFile();
     const broke = produce(state, s => {
       s.player.charges = 0;
     });
     const result = await resolveCommand(`unlock ${fileName}`, broke);
     expect(result.lines.some(l => l.content.includes('insufficient charges'))).toBe(true);
+    const nextState = result.nextState as GameState;
     // Session must not have been started
-    expect((result.nextState as GameState | undefined)?.unlockSession).toBeNull();
+    expect(nextState.unlockSession).toBeNull();
+    // Attempt counter must not have been incremented (guard fires before attempts are touched)
+    expect(nextState.unlockAttempts[filePath] ?? 0).toBe(0);
   });
 
   it('success stamps threshold flag when unlock crosses a trace threshold', async () => {
@@ -3374,9 +3377,12 @@ describe('unlock command', () => {
     const { state, fileName, filePath } = stateWithLockedFile();
     const r1 = await resolveCommand(`unlock ${fileName}`, state);
     const s1 = r1.nextState as GameState;
-    // Type the correct code in lowercase — should be abandonment, not a burn
-    const lowerCode = s1.unlockSession!.codes[0].toLowerCase();
-    const result = await resolveCommand(lowerCode, s1);
+    // Pin codes[0] to a known value containing letters so toLowerCase() is always a real change
+    const pinned = produce(s1, s => {
+      s.unlockSession!.codes[0] = 'ABCD-EFGH';
+    });
+    const lowerCode = 'abcd-efgh';
+    const result = await resolveCommand(lowerCode, pinned);
     const next = result.nextState as GameState;
     expect(next.unlockSession).toBeNull();
     expect(next.unlockAttempts[filePath]).toBe(1);

--- a/src/engine/commands.test.ts
+++ b/src/engine/commands.test.ts
@@ -3340,4 +3340,60 @@ describe('unlock command', () => {
       expect(code).not.toMatch(/[01IO]/);
     }
   });
+
+  it('returns error when player has no charges', async () => {
+    const { state, fileName } = stateWithLockedFile();
+    const broke = produce(state, s => {
+      s.player.charges = 0;
+    });
+    const result = await resolveCommand(`unlock ${fileName}`, broke);
+    expect(result.lines.some(l => l.content.includes('insufficient charges'))).toBe(true);
+    // Session must not have been started
+    expect((result.nextState as GameState | undefined)?.unlockSession).toBeNull();
+  });
+
+  it('success stamps threshold flag when unlock crosses a trace threshold', async () => {
+    const { state, fileName } = stateWithLockedFile();
+    // Set trace just below 31% so the +5 from success crosses the threshold
+    const nearThreshold = produce(state, s => {
+      s.player.trace = 28;
+    });
+    const r1 = await resolveCommand(`unlock ${fileName}`, nearThreshold);
+    const s1 = r1.nextState as GameState;
+    const r2 = await resolveCommand(s1.unlockSession!.codes[0], s1);
+    const s2 = r2.nextState as GameState;
+    const r3 = await resolveCommand(s2.unlockSession!.codes[1], s2);
+    const s3 = r3.nextState as GameState;
+    const r4 = await resolveCommand(s3.unlockSession!.codes[2], s3);
+    const s4 = r4.nextState as GameState;
+    expect(s4.player.trace).toBe(33);
+    expect(s4.flags['threshold_31_crossed']).toBe(true);
+  });
+
+  it('lowercase code is treated as abandonment, not a wrong-code attempt', async () => {
+    const { state, fileName, filePath } = stateWithLockedFile();
+    const r1 = await resolveCommand(`unlock ${fileName}`, state);
+    const s1 = r1.nextState as GameState;
+    // Type the correct code in lowercase — should be abandonment, not a burn
+    const lowerCode = s1.unlockSession!.codes[0].toLowerCase();
+    const result = await resolveCommand(lowerCode, s1);
+    const next = result.nextState as GameState;
+    expect(next.unlockSession).toBeNull();
+    expect(next.unlockAttempts[filePath]).toBe(1);
+    expect(result.lines.some(l => l.content.includes('interrupted'))).toBe(true);
+    expect(result.lines.some(l => l.content.includes('Wrong code'))).toBe(false);
+  });
+
+  it('code containing excluded chars (0, 1, I, O) is treated as abandonment', async () => {
+    const { state, fileName, filePath } = stateWithLockedFile();
+    const r1 = await resolveCommand(`unlock ${fileName}`, state);
+    const s1 = r1.nextState as GameState;
+    // A000-B111 looks like a code but contains excluded chars — abandonment
+    const result = await resolveCommand('A000-B111', s1);
+    const next = result.nextState as GameState;
+    expect(next.unlockSession).toBeNull();
+    expect(next.unlockAttempts[filePath]).toBe(1);
+    expect(result.lines.some(l => l.content.includes('interrupted'))).toBe(true);
+    expect(result.lines.some(l => l.content.includes('Wrong code'))).toBe(false);
+  });
 });

--- a/src/engine/commands.ts
+++ b/src/engine/commands.ts
@@ -175,7 +175,7 @@ export const resolveCommand = async (raw: string, state: GameState): Promise<Com
         s.unlockSession = null;
         s.unlockAttempts[filePath] = attempts;
       });
-      const CODE_PATTERN = /^[A-Z0-9]{4}-[A-Z0-9]{4}$/i;
+      const CODE_PATTERN = /^[A-HJ-NP-Z2-9]{4}-[A-HJ-NP-Z2-9]{4}$/;
       const looksLikeCode = CODE_PATTERN.test(raw.trim());
       const isAbandonment = !looksLikeCode;
       const failMsg = isAbandonment


### PR DESCRIPTION
## Summary

- **#133** — Tighten `CODE_PATTERN` to exact `UNLOCK_CODE_CHARS` charset, remove `/i` flag: lowercase and excluded-char (`0`, `1`, `I`, `O`) inputs now route as abandonment instead of silently burning an attempt
- **#131** — Charge guard already in place; add missing test that blocks session start with 0 charges
- **#128** — `addTrace` already in place; add missing test that verifies threshold flag stamps on unlock success

## Test Plan
- [ ] `unlock <file>` with 0 charges returns "insufficient charges" error, no session started
- [ ] Lowercase code during session → abandonment message, not "Wrong code"
- [ ] Code with `0`/`1`/`I`/`O` during session → abandonment, not wrong-code burn
- [ ] Unlock success at trace=28 stamps `threshold_31_crossed` flag
- [ ] `npm test` — 1281 passing

Closes #128, #131, #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)