### PR TITLE
feat(engine): §9.2 mutation log completeness audit — add reason field

### DIFF
--- a/src/engine/__tests__/ariaMutations.test.ts
+++ b/src/engine/__tests__/ariaMutations.test.ts
@@ -600,3 +600,70 @@ describe('runAriaTurn — mutation priority', () => {
     expect(events[0].action).toBe('delete_reinforcement');
   });
 });
+
+// ── MutationEvent.reason field ─────────────────────────────
+
+describe('runAriaTurn — MutationEvent.reason populated', () => {
+  it('reroute_edge event has a non-empty reason string', () => {
+    const current = makeNode({
+      id: 'current',
+      ip: '10.0.0.1',
+      layer: 0,
+      connections: ['vpn_gateway'],
+    });
+    const vpnGateway = makeNode({
+      id: 'vpn_gateway',
+      ip: '10.1.0.1',
+      layer: 1,
+      anchor: true,
+      connections: [],
+      compromised: true,
+    });
+    const anchorL2 = makeAnchorAt(2, 'anchor_l2');
+
+    const state = makeState({
+      network: {
+        currentNodeId: 'current',
+        previousNodeId: null,
+        nodes: { current, vpn_gateway: vpnGateway, anchor_l2: anchorL2 },
+      },
+      aria: { discovered: true, trustScore: 60, messageHistory: [], suppressedMutations: 0 },
+      player: {
+        handle: 'ghost',
+        trace: 0,
+        charges: 3,
+        credentials: [],
+        exfiltrated: [],
+        tools: [],
+        burnCount: 0,
+      },
+    });
+
+    const result = runAriaTurn(state);
+    const event = result.state.sentinel.mutationLog[0];
+    expect(event.action).toBe('reroute_edge');
+    expect(typeof event.reason).toBe('string');
+    expect(event.reason!.length).toBeGreaterThan(0);
+  });
+
+  it('delete_reinforcement event has a non-empty reason string', () => {
+    const sentinelNode = makeSentinelNode(1, { connections: [] });
+    const state = makeAriaState({
+      network: {
+        currentNodeId: 'current',
+        previousNodeId: null,
+        nodes: {
+          current: makeNode({ id: 'current', ip: '10.5.0.1', layer: 5, connections: [] }),
+          sentinel_node_1: sentinelNode,
+        },
+      },
+      aria: { discovered: true, trustScore: 85, messageHistory: [], suppressedMutations: 0 },
+    });
+
+    const result = runAriaTurn(state);
+    const event = result.state.sentinel.mutationLog[0];
+    expect(event.action).toBe('delete_reinforcement');
+    expect(typeof event.reason).toBe('string');
+    expect(event.reason!.length).toBeGreaterThan(0);
+  });
+});

--- a/src/engine/ariaMutations.ts
+++ b/src/engine/ariaMutations.ts
@@ -39,7 +39,10 @@ const tryDeleteReinforcement = (
   if (sentinelNodes.length === 0) return null;
 
   const target = sentinelNodes[0];
-  const event = makeMutationEvent('delete_reinforcement', state.turnCount, { nodeId: target.id });
+  const event = makeMutationEvent('delete_reinforcement', state.turnCount, {
+    nodeId: target.id,
+    reason: 'Removing sentinel reinforcement node to aid player progress',
+  });
 
   const next = produce(state, s => {
     // Remove the node from the network (set to undefined to satisfy no-dynamic-delete)
@@ -79,7 +82,10 @@ const tryRerouteEdge = (state: GameState): { state: GameState; lines: AriaLine[]
   if (candidates.length === 0) return null;
 
   const target = candidates[0];
-  const event = makeMutationEvent('reroute_edge', state.turnCount, { nodeId: target.id });
+  const event = makeMutationEvent('reroute_edge', state.turnCount, {
+    nodeId: target.id,
+    reason: 'Adding shortcut edge to accelerate player navigation',
+  });
 
   const next = produce(state, s => {
     const node = s.network.nodes[s.network.currentNodeId];

--- a/src/engine/postGameReadout.test.ts
+++ b/src/engine/postGameReadout.test.ts
@@ -639,3 +639,58 @@ describe('buildPostGameReadout', () => {
     expect(eventLine?.content).toContain('removed from network');
   });
 });
+
+// ── reason field rendering ─────────────────────────────────
+
+describe('buildPostGameReadout — reason field appended when present', () => {
+  it('appends reason to a sentinel patch_node line', () => {
+    const state = produce(withEnding(createInitialState(), 'LEAK'), s => {
+      s.sentinel.mutationLog.push(
+        makeMutation('patch_node', 3, { nodeId: 'ops_node', reason: 'Hardening test reason' }),
+      );
+    });
+    const lines = buildPostGameReadout(state);
+    const eventLine = lines.find(l => l.type === 'error' && l.content.includes('SENTINEL:'));
+    expect(eventLine?.content).toContain('— Hardening test reason');
+  });
+
+  it('does not append separator when reason is absent on a sentinel event', () => {
+    const state = produce(withEnding(createInitialState(), 'SELL'), s => {
+      s.sentinel.mutationLog.push(makeMutation('patch_node', 3, { nodeId: 'ops_node' }));
+    });
+    const lines = buildPostGameReadout(state);
+    const eventLine = lines.find(l => l.type === 'error' && l.content.includes('SENTINEL:'));
+    expect(eventLine?.content).not.toContain('—');
+  });
+
+  it('appends reason to an aria reroute_edge line', () => {
+    const state = produce(withEnding(createInitialState(), 'FREE'), s => {
+      s.sentinel.mutationLog.push(
+        makeMutation('reroute_edge', 7, {
+          agent: 'aria',
+          visibleToPlayer: false,
+          nodeId: 'exec_node',
+          reason: 'Aiding navigation',
+        }),
+      );
+    });
+    const lines = buildPostGameReadout(state);
+    const eventLine = lines.find(l => l.type === 'aria' && l.content.includes('ARIA:'));
+    expect(eventLine?.content).toContain('— Aiding navigation');
+  });
+
+  it('does not append separator when reason is absent on an aria event', () => {
+    const state = produce(withEnding(createInitialState(), 'FREE'), s => {
+      s.sentinel.mutationLog.push(
+        makeMutation('reroute_edge', 7, {
+          agent: 'aria',
+          visibleToPlayer: false,
+          nodeId: 'exec_node',
+        }),
+      );
+    });
+    const lines = buildPostGameReadout(state);
+    const eventLine = lines.find(l => l.type === 'aria' && l.content.includes('ARIA:'));
+    expect(eventLine?.content).not.toContain('—');
+  });
+});

--- a/src/engine/postGameReadout.test.ts
+++ b/src/engine/postGameReadout.test.ts
@@ -654,7 +654,7 @@ describe('buildPostGameReadout — reason field appended when present', () => {
     expect(eventLine?.content).toContain('— Hardening test reason');
   });
 
-  it('does not append separator when reason is absent on a sentinel event', () => {
+  it('does not append reason suffix when reason is absent on a sentinel event', () => {
     const state = produce(withEnding(createInitialState(), 'SELL'), s => {
       s.sentinel.mutationLog.push(makeMutation('patch_node', 3, { nodeId: 'ops_node' }));
     });
@@ -679,7 +679,7 @@ describe('buildPostGameReadout — reason field appended when present', () => {
     expect(eventLine?.content).toContain('— Aiding navigation');
   });
 
-  it('does not append separator when reason is absent on an aria event', () => {
+  it('does not append reason suffix when reason is absent on an aria event', () => {
     const state = produce(withEnding(createInitialState(), 'FREE'), s => {
       s.sentinel.mutationLog.push(
         makeMutation('reroute_edge', 7, {

--- a/src/engine/postGameReadout.ts
+++ b/src/engine/postGameReadout.ts
@@ -3,20 +3,35 @@ import type { LineType } from '../types/terminal';
 
 export type ReadoutLine = { type: LineType; content: string };
 
+const withReason = (base: string, reason: string | undefined): string =>
+  reason ? `${base} — ${reason}` : base;
+
 const formatSentinelEvent = (event: MutationEvent): string => {
   const turn = String(event.turnCount).padStart(3, '0');
   const prefix = `  T${turn} SENTINEL:`;
   switch (event.action) {
     case 'patch_node':
-      return `${prefix} Node '${event.nodeId ?? '?'}' hardened (+1 exploit charge)`;
+      return withReason(
+        `${prefix} Node '${event.nodeId ?? '?'}' hardened (+1 exploit charge)`,
+        event.reason,
+      );
     case 'revoke_credential':
-      return `${prefix} Credential '${event.credentialId ?? '?'}' revoked on '${event.nodeId ?? '?'}'`;
+      return withReason(
+        `${prefix} Credential '${event.credentialId ?? '?'}' revoked on '${event.nodeId ?? '?'}'`,
+        event.reason,
+      );
     case 'delete_file': {
       const fileName = (event.filePath ?? '?').split('/').pop() ?? '?';
-      return `${prefix} File '${fileName}' deleted from '${event.nodeId ?? '?'}'`;
+      return withReason(
+        `${prefix} File '${fileName}' deleted from '${event.nodeId ?? '?'}'`,
+        event.reason,
+      );
     }
     case 'spawn_node':
-      return `${prefix} Reinforcement node '${event.nodeId ?? '?'}' deployed`;
+      return withReason(
+        `${prefix} Reinforcement node '${event.nodeId ?? '?'}' deployed`,
+        event.reason,
+      );
     default:
       return `${prefix} Unknown action`;
   }
@@ -28,18 +43,27 @@ const formatAriaEvent = (event: MutationEvent): string => {
   switch (event.action) {
     case 'plant_file': {
       const fileName = (event.filePath ?? '?').split('/').pop() ?? '?';
-      return `${prefix} File '${fileName}' planted on '${event.nodeId ?? '?'}'`;
+      return withReason(
+        `${prefix} File '${fileName}' planted on '${event.nodeId ?? '?'}'`,
+        event.reason,
+      );
     }
     case 'modify_file': {
       const fileName = (event.filePath ?? '?').split('/').pop() ?? '?';
-      return `${prefix} File '${fileName}' modified on '${event.nodeId ?? '?'}'`;
+      return withReason(
+        `${prefix} File '${fileName}' modified on '${event.nodeId ?? '?'}'`,
+        event.reason,
+      );
     }
     case 'nudge_trust':
-      return `${prefix} Trust score adjusted silently`;
+      return withReason(`${prefix} Trust score adjusted silently`, event.reason);
     case 'reroute_edge':
-      return `${prefix} Shortcut edge added to '${event.nodeId ?? '?'}'`;
+      return withReason(`${prefix} Shortcut edge added to '${event.nodeId ?? '?'}'`, event.reason);
     case 'delete_reinforcement':
-      return `${prefix} Reinforcement node '${event.nodeId ?? '?'}' removed from network`;
+      return withReason(
+        `${prefix} Reinforcement node '${event.nodeId ?? '?'}' removed from network`,
+        event.reason,
+      );
     default:
       return `${prefix} Silent operation performed`;
   }

--- a/src/engine/sentinel.test.ts
+++ b/src/engine/sentinel.test.ts
@@ -764,3 +764,67 @@ describe('runSentinelTurn — priority 1: reduce tie-break branches', () => {
     expect(result.state.network.nodes['vpn_gateway']?.sentinelPatched).toBeFalsy();
   });
 });
+
+// ── MutationEvent.reason field ─────────────────────────────
+
+describe('runSentinelTurn — MutationEvent.reason populated', () => {
+  it('patch_node event has a non-empty reason string', () => {
+    const state = produce(activeState(), s => {
+      const n = s.network.nodes['contractor_portal'];
+      if (n) {
+        n.compromised = true;
+        n.compromisedAtTurn = 1;
+        n.layer = 1;
+      }
+    });
+    const result = runSentinelTurn(state);
+    const event = result.state.sentinel.mutationLog[0];
+    expect(event.action).toBe('patch_node');
+    expect(typeof event.reason).toBe('string');
+    expect(event.reason!.length).toBeGreaterThan(0);
+  });
+
+  it('revoke_credential event has a non-empty reason string', () => {
+    const base = patchAllCompromised(
+      produce(activeState(), s => {
+        const n = s.network.nodes['contractor_portal'];
+        if (n) {
+          n.compromised = true;
+          n.compromisedAtTurn = 1;
+          n.layer = 1;
+        }
+      }),
+    );
+    const state = obtainFirstCredential(base);
+    const result = runSentinelTurn(state);
+    const event = result.state.sentinel.mutationLog[0];
+    expect(event.action).toBe('revoke_credential');
+    expect(typeof event.reason).toBe('string');
+    expect(event.reason!.length).toBeGreaterThan(0);
+  });
+
+  it('delete_file event has a non-empty reason string', () => {
+    const base = patchAllCompromised(revokeAllCredentials(activeState()));
+    const state = produce(base, s => {
+      s.sentinel.pendingFileDeletes.push({
+        filePath: '/data/report.txt',
+        nodeId: 'contractor_portal',
+        targetTurn: 0,
+      });
+    });
+    const result = runSentinelTurn(state);
+    const event = result.state.sentinel.mutationLog.find(e => e.action === 'delete_file');
+    expect(event).toBeDefined();
+    expect(typeof event!.reason).toBe('string');
+    expect(event!.reason!.length).toBeGreaterThan(0);
+  });
+
+  it('spawn_node event has a non-empty reason string', () => {
+    const state = patchAllCompromised(revokeAllCredentials(activeState()));
+    const result = runSentinelTurn(state);
+    const event = result.state.sentinel.mutationLog.find(e => e.action === 'spawn_node');
+    expect(event).toBeDefined();
+    expect(typeof event!.reason).toBe('string');
+    expect(event!.reason!.length).toBeGreaterThan(0);
+  });
+});

--- a/src/engine/sentinel.ts
+++ b/src/engine/sentinel.ts
@@ -50,7 +50,10 @@ const tryPatchNode = (state: GameState): { state: GameState; lines: SentinelLine
     return n.id < best.id ? n : best;
   });
 
-  const event = makeMutationEvent('patch_node', state.turnCount, { nodeId: target.id });
+  const event = makeMutationEvent('patch_node', state.turnCount, {
+    nodeId: target.id,
+    reason: 'Hardening compromised node to slow intrusion',
+  });
   const next = produce(state, s => {
     const node = s.network.nodes[target.id];
     if (node) node.sentinelPatched = true;
@@ -109,6 +112,7 @@ const tryRevokeCredential = (
   const event = makeMutationEvent('revoke_credential', state.turnCount, {
     credentialId: target.id,
     nodeId: primaryNodeId,
+    reason: 'Rotating credentials after breach detected',
   });
 
   const next = produce(state, s => {
@@ -211,6 +215,7 @@ const tryDeleteFile = (state: GameState): { state: GameState; lines: SentinelLin
       makeMutationEvent('delete_file', state.turnCount, {
         nodeId: pending.nodeId,
         filePath: pending.filePath,
+        reason: 'Destroying source file after exfiltration detected',
       }),
     );
   });
@@ -245,7 +250,10 @@ const trySpawnNode = (state: GameState): { state: GameState; lines: SentinelLine
     .map(n => n.id)
     .slice(0, 2);
 
-  const event = makeMutationEvent('spawn_node', state.turnCount, { nodeId });
+  const event = makeMutationEvent('spawn_node', state.turnCount, {
+    nodeId,
+    reason: 'Deploying reinforcement node in response to sustained intrusion',
+  });
 
   const next = produce(state, s => {
     s.network.nodes[nodeId] = {

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -196,6 +196,7 @@ export interface MutationEvent {
   action: SentinelAction | AriaAction;
   turnCount: number;
   visibleToPlayer: boolean;
+  reason?: string;
   nodeId?: string;
   credentialId?: string;
   filePath?: string;


### PR DESCRIPTION
## Summary

**Engine — MutationEvent type**
- Added `reason?: string` to `MutationEvent` interface (optional, backward-compatible)

**Engine — Sentinel mutations**
- Populated `reason` string in all 4 `makeMutationEvent` calls in `sentinel.ts`: `patch_node`, `revoke_credential`, `delete_file`, `spawn_node`

**Engine — Aria mutations**
- Populated `reason` string in both implemented `makeMutationEvent` calls in `ariaMutations.ts`: `reroute_edge`, `delete_reinforcement`

**Engine — Post-game readout**
- Added `withReason()` helper that appends `— <reason>` to a readout line when a reason is present
- Applied to all 4 sentinel formatters and all 5 aria formatters in `postGameReadout.ts`

**Tests**
- Added 4 sentinel tests asserting `reason` is a non-empty string for each `SentinelAction`
- Added 2 aria tests asserting `reason` is a non-empty string for each implemented `AriaAction`
- Added 4 readout tests verifying reason is appended when present and absent when not

**Audit findings**
| Mutation | Agent | `visibleToPlayer` | Logged? |
|---|---|---|---|
| `patch_node` | sentinel | `true` | ✓ |
| `revoke_credential` | sentinel | `true` | ✓ |
| `delete_file` | sentinel | `true` | ✓ |
| `spawn_node` | sentinel | `true` | ✓ |
| `delete_reinforcement` | aria | `false` | ✓ |
| `reroute_edge` | aria | `false` | ✓ |
| `plant_file` | aria | — | not implemented (Phase 6 stub) |
| `modify_file` | aria | — | not implemented (Phase 6 stub) |
| `nudge_trust` | aria | — | not implemented (Phase 6 stub) |

Closes #28

## Test plan
- [x] Unit tests pass (1307 tests, 10 new)
- [x] Typecheck passes (`npm run build` clean)
- [x] Lint passes (`npm run lint` clean)
- [ ] Smoke tested: dev server start not available in this session — build + type safety provides strong coverage for pure function changes

## Known limitations
- `plant_file`, `modify_file`, `nudge_trust` aria actions are type-defined and handled in the readout formatter but not yet implemented in `ariaMutations.ts` — Phase 6 work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>