### PR TITLE
feat(contracts): author all 10 contracts with unlock progression

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -360,7 +360,7 @@ export const App = () => {
         bootHandled.current = false;
         const dossierAfterEnd = loadDossier();
         if (dossierAfterEnd.runsCompleted > 0) {
-          const contract = selectContract();
+          const contract = selectContract(undefined, dossierAfterEnd.runsCompleted);
           setPendingContract(contract);
           setContractRerollUsed(false);
           setSessionLines(buildContractLines(contract));
@@ -406,7 +406,7 @@ export const App = () => {
           } else {
             const dossier = loadDossier();
             if (dossier.runsCompleted > 0) {
-              const contract = selectContract();
+              const contract = selectContract(undefined, dossier.runsCompleted);
               setPendingContract(contract);
               setContractRerollUsed(false);
               setSessionLines(buildContractLines(contract));
@@ -445,7 +445,7 @@ export const App = () => {
           if (contractRerollUsed) {
             push([makeLine('system', '// REROLL: already used — one reroll per session')]);
           } else {
-            const rerolled = selectContract(pendingContract?.id);
+            const rerolled = selectContract(pendingContract?.id, loadDossier().runsCompleted);
             setPendingContract(rerolled);
             setContractRerollUsed(true);
             push(buildContractLines(rerolled));
@@ -475,7 +475,7 @@ export const App = () => {
           clearSave();
           const dossier = loadDossier();
           if (dossier.runsCompleted > 0) {
-            const contract = selectContract();
+            const contract = selectContract(undefined, dossier.runsCompleted);
             setPendingContract(contract);
             setContractRerollUsed(false);
             setSessionLines(buildContractLines(contract));
@@ -630,16 +630,33 @@ export const App = () => {
           // Do NOT clearSave here — state is needed for burnRetry on Enter.
         } else if (next.phase === 'ended') {
           // Finalise objective for condition types evaluated at run-end rather than mid-run.
+          // Layer → divisionId mapping for avoid_division end-of-run checks.
+          const DIVISION_LAYER: Record<string, number | undefined> = {
+            external_perimeter: 0,
+            operations: 1,
+            security: 2,
+            finance: 3,
+            executive: 4,
+          };
           const activeContract = next.contract;
           const finalNext =
             activeContract && !activeContract.objectiveComplete
               ? produce(next, s => {
                   if (!s.contract) return;
-                  const type = s.contract.objectiveCondition.type;
-                  if (type === 'trace_cap' && !s.flags['contract_cap_exceeded']) {
+                  const condition = s.contract.objectiveCondition;
+                  if (condition.type === 'trace_cap' && !s.flags['contract_cap_exceeded']) {
                     s.contract.objectiveComplete = true;
-                  } else if (type === 'no_burn' && s.player.burnCount === 0) {
+                  } else if (condition.type === 'no_burn' && s.player.burnCount === 0) {
                     s.contract.objectiveComplete = true;
+                  } else if (condition.type === 'avoid_division') {
+                    const avoidCond = condition as { type: 'avoid_division'; divisionId: string };
+                    const targetLayer = DIVISION_LAYER[avoidCond.divisionId];
+                    if (targetLayer !== undefined) {
+                      const anyCompromised = Object.values(s.network.nodes).some(
+                        n => n?.layer === targetLayer && n.compromised,
+                      );
+                      if (!anyCompromised) s.contract.objectiveComplete = true;
+                    }
                   }
                 })
               : next;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,8 @@ import {
 } from './engine/persistence';
 import { loadDossier } from './engine/dossierPersistence';
 import { selectContract } from './data/contracts';
+import { DIVISION_LAYER } from './engine/buildCredentialChains';
+import type { DivisionId } from './types/divisionSeed';
 import type { ContractDefinition } from './types/game';
 
 const computeContextSuggestions = (state: GameState): string[] => {
@@ -630,14 +632,6 @@ export const App = () => {
           // Do NOT clearSave here — state is needed for burnRetry on Enter.
         } else if (next.phase === 'ended') {
           // Finalise objective for condition types evaluated at run-end rather than mid-run.
-          // Layer → divisionId mapping for avoid_division end-of-run checks.
-          const DIVISION_LAYER: Record<string, number | undefined> = {
-            external_perimeter: 0,
-            operations: 1,
-            security: 2,
-            finance: 3,
-            executive: 4,
-          };
           const activeContract = next.contract;
           const finalNext =
             activeContract && !activeContract.objectiveComplete
@@ -649,14 +643,11 @@ export const App = () => {
                   } else if (condition.type === 'no_burn' && s.player.burnCount === 0) {
                     s.contract.objectiveComplete = true;
                   } else if (condition.type === 'avoid_division') {
-                    const avoidCond = condition as { type: 'avoid_division'; divisionId: string };
-                    const targetLayer = DIVISION_LAYER[avoidCond.divisionId];
-                    if (targetLayer !== undefined) {
-                      const anyCompromised = Object.values(s.network.nodes).some(
-                        n => n?.layer === targetLayer && n.compromised,
-                      );
-                      if (!anyCompromised) s.contract.objectiveComplete = true;
-                    }
+                    const targetLayer = DIVISION_LAYER[condition.divisionId as DivisionId];
+                    const anyCompromised = Object.values(s.network.nodes).some(
+                      n => n?.layer === targetLayer && n.compromised,
+                    );
+                    if (!anyCompromised) s.contract.objectiveComplete = true;
                   }
                 })
               : next;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,8 +29,7 @@ import {
 } from './engine/persistence';
 import { loadDossier } from './engine/dossierPersistence';
 import { selectContract } from './data/contracts';
-import { DIVISION_LAYER } from './engine/buildCredentialChains';
-import type { DivisionId } from './types/divisionSeed';
+import { DIVISION_LAYER } from './data/divisionSeeds';
 import type { ContractDefinition } from './types/game';
 
 const computeContextSuggestions = (state: GameState): string[] => {
@@ -643,7 +642,7 @@ export const App = () => {
                   } else if (condition.type === 'no_burn' && s.player.burnCount === 0) {
                     s.contract.objectiveComplete = true;
                   } else if (condition.type === 'avoid_division') {
-                    const targetLayer = DIVISION_LAYER[condition.divisionId as DivisionId];
+                    const targetLayer = DIVISION_LAYER[condition.divisionId];
                     const anyCompromised = Object.values(s.network.nodes).some(
                       n => n?.layer === targetLayer && n.compromised,
                     );

--- a/src/data/contracts.test.ts
+++ b/src/data/contracts.test.ts
@@ -413,9 +413,9 @@ describe('selectContract', () => {
     expect(CONTRACT_POOL).toContain(result);
   });
 
-  it('should fall back to the unlocked pool when excludeId would exclude all eligible contracts', () => {
+  it('should return a valid contract when excludeId does not match any eligible contract', () => {
     // With runsCompleted=1 the base pool has 3 contracts. Excluding a nonexistent ID
-    // leaves the eligible pool unchanged — verifies the fallback path is consistent.
+    // leaves the eligible pool unchanged — verifies normal selection still works.
     const result = selectContract('nonexistent', 1);
     expect(result).toBeDefined();
     expect(typeof result.id).toBe('string');

--- a/src/data/contracts.test.ts
+++ b/src/data/contracts.test.ts
@@ -44,17 +44,25 @@ describe('CONTRACT_POOL', () => {
     'objectiveCondition',
   ] as const;
 
-  it('should contain exactly 5 contracts', () => {
-    expect(CONTRACT_POOL).toHaveLength(5);
+  it('should contain exactly 10 contracts', () => {
+    expect(CONTRACT_POOL).toHaveLength(10);
   });
 
   it('should contain the expected contract IDs', () => {
     const ids = CONTRACT_POOL.map(c => c.id);
+    // Basic pool (run 2+)
     expect(ids).toContain('ghost_protocol');
     expect(ids).toContain('data_harvest');
     expect(ids).toContain('blitz');
+    // Mid pool (run 3+)
     expect(ids).toContain('scorched_earth');
     expect(ids).toContain('clean_sweep');
+    expect(ids).toContain('inside_job');
+    // Full pool (run 4+)
+    expect(ids).toContain('paper_trail');
+    expect(ids).toContain('dark_corridor');
+    expect(ids).toContain('board_exposure');
+    expect(ids).toContain('zero_footprint');
   });
 
   it.each(CONTRACT_POOL)(
@@ -90,7 +98,14 @@ describe('CONTRACT_POOL', () => {
   );
 
   it.each(CONTRACT_POOL)('contract "$id" objectiveCondition should have a known type', contract => {
-    const validTypes = ['trace_cap', 'exfil_count', 'no_burn'];
+    const validTypes = [
+      'trace_cap',
+      'exfil_count',
+      'no_burn',
+      'exfil_file',
+      'identify_employee',
+      'avoid_division',
+    ];
     expect(validTypes).toContain(contract.objectiveCondition.type);
   });
 
@@ -119,9 +134,122 @@ describe('CONTRACT_POOL', () => {
     expect(contract.objectiveCondition).toEqual({ type: 'no_burn' });
   });
 
+  it('paper_trail should have an exfil_file condition for wire_transfers_q4.csv', () => {
+    const contract = CONTRACT_POOL.find(c => c.id === 'paper_trail')!;
+    expect(contract.objectiveCondition).toEqual({
+      type: 'exfil_file',
+      targetFileName: 'wire_transfers_q4.csv',
+    });
+  });
+
+  it('board_exposure should have an exfil_file condition for board_minutes_oct.pdf', () => {
+    const contract = CONTRACT_POOL.find(c => c.id === 'board_exposure')!;
+    expect(contract.objectiveCondition).toEqual({
+      type: 'exfil_file',
+      targetFileName: 'board_minutes_oct.pdf',
+    });
+  });
+
+  it('dark_corridor should have an avoid_division condition for security', () => {
+    const contract = CONTRACT_POOL.find(c => c.id === 'dark_corridor')!;
+    expect(contract.objectiveCondition).toEqual({ type: 'avoid_division', divisionId: 'security' });
+  });
+
+  it('inside_job should have an identify_employee condition for security division', () => {
+    const contract = CONTRACT_POOL.find(c => c.id === 'inside_job')!;
+    expect(contract.objectiveCondition).toEqual({
+      type: 'identify_employee',
+      divisionId: 'security',
+    });
+  });
+
+  it('zero_footprint should have an identify_employee condition for finance division', () => {
+    const contract = CONTRACT_POOL.find(c => c.id === 'zero_footprint')!;
+    expect(contract.objectiveCondition).toEqual({
+      type: 'identify_employee',
+      divisionId: 'finance',
+    });
+  });
+
   it('all contract IDs should be unique', () => {
     const ids = CONTRACT_POOL.map(c => c.id);
     expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  // ── unlockedAfterRun progression ─────────────────────────
+  it('basic pool (unlockedAfterRun=0) should have exactly 3 contracts', () => {
+    const basic = CONTRACT_POOL.filter(c => (c.unlockedAfterRun ?? 0) === 0);
+    expect(basic).toHaveLength(3);
+    expect(basic.map(c => c.id)).toEqual(
+      expect.arrayContaining(['ghost_protocol', 'data_harvest', 'blitz']),
+    );
+  });
+
+  it('mid pool (unlockedAfterRun=1) should have exactly 3 contracts', () => {
+    const mid = CONTRACT_POOL.filter(c => (c.unlockedAfterRun ?? 0) === 1);
+    expect(mid).toHaveLength(3);
+    expect(mid.map(c => c.id)).toEqual(
+      expect.arrayContaining(['scorched_earth', 'clean_sweep', 'inside_job']),
+    );
+  });
+
+  it('full pool addition (unlockedAfterRun=2) should have exactly 4 contracts', () => {
+    const full = CONTRACT_POOL.filter(c => (c.unlockedAfterRun ?? 0) === 2);
+    expect(full).toHaveLength(4);
+    expect(full.map(c => c.id)).toEqual(
+      expect.arrayContaining(['paper_trail', 'dark_corridor', 'board_exposure', 'zero_footprint']),
+    );
+  });
+
+  // ── rewardOnComplete ──────────────────────────────────────
+  it('contracts with rewardOnComplete should have non-empty string values', () => {
+    for (const contract of CONTRACT_POOL) {
+      if (contract.rewardOnComplete !== undefined) {
+        expect(contract.rewardOnComplete.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('inside_job should reward SECURITY_INSIDER_IDENTIFIED on completion', () => {
+    const contract = CONTRACT_POOL.find(c => c.id === 'inside_job')!;
+    expect(contract.rewardOnComplete).toBe('SECURITY_INSIDER_IDENTIFIED');
+  });
+
+  it('paper_trail should reward WIRE_TRANSFERS_OBTAINED on completion', () => {
+    const contract = CONTRACT_POOL.find(c => c.id === 'paper_trail')!;
+    expect(contract.rewardOnComplete).toBe('WIRE_TRANSFERS_OBTAINED');
+  });
+
+  it('dark_corridor should reward SECURITY_BYPASSED on completion', () => {
+    const contract = CONTRACT_POOL.find(c => c.id === 'dark_corridor')!;
+    expect(contract.rewardOnComplete).toBe('SECURITY_BYPASSED');
+  });
+
+  it('board_exposure should reward BOARD_EXPOSED on completion', () => {
+    const contract = CONTRACT_POOL.find(c => c.id === 'board_exposure')!;
+    expect(contract.rewardOnComplete).toBe('BOARD_EXPOSED');
+  });
+
+  it('zero_footprint should reward FINANCE_PERSONNEL_IDENTIFIED on completion', () => {
+    const contract = CONTRACT_POOL.find(c => c.id === 'zero_footprint')!;
+    expect(contract.rewardOnComplete).toBe('FINANCE_PERSONNEL_IDENTIFIED');
+  });
+
+  // ── Insider loadout contracts ─────────────────────────────
+  it('inside_job should start with cred_sec_analyst pre-obtained', () => {
+    const contract = CONTRACT_POOL.find(c => c.id === 'inside_job')!;
+    expect(contract.loadout.startingCredentials).toContain('cred_sec_analyst');
+  });
+
+  it('zero_footprint should start with cred_fin_analyst pre-obtained', () => {
+    const contract = CONTRACT_POOL.find(c => c.id === 'zero_footprint')!;
+    expect(contract.loadout.startingCredentials).toContain('cred_fin_analyst');
+  });
+
+  // ── Equipped loadout contracts ────────────────────────────
+  it('paper_trail should include decryptor in startingTools', () => {
+    const contract = CONTRACT_POOL.find(c => c.id === 'paper_trail')!;
+    expect(contract.loadout.startingTools).toContain('decryptor');
   });
 });
 
@@ -157,6 +285,37 @@ describe('getContract', () => {
     const result = getContract('clean_sweep');
     expect(result).toBeDefined();
     expect(result!.id).toBe('clean_sweep');
+  });
+
+  it('should return the inside_job contract when queried by id', () => {
+    const result = getContract('inside_job');
+    expect(result).toBeDefined();
+    expect(result!.id).toBe('inside_job');
+    expect(result!.title).toBe('INSIDE JOB');
+  });
+
+  it('should return the paper_trail contract when queried by id', () => {
+    const result = getContract('paper_trail');
+    expect(result).toBeDefined();
+    expect(result!.id).toBe('paper_trail');
+  });
+
+  it('should return the dark_corridor contract when queried by id', () => {
+    const result = getContract('dark_corridor');
+    expect(result).toBeDefined();
+    expect(result!.id).toBe('dark_corridor');
+  });
+
+  it('should return the board_exposure contract when queried by id', () => {
+    const result = getContract('board_exposure');
+    expect(result).toBeDefined();
+    expect(result!.id).toBe('board_exposure');
+  });
+
+  it('should return the zero_footprint contract when queried by id', () => {
+    const result = getContract('zero_footprint');
+    expect(result).toBeDefined();
+    expect(result!.id).toBe('zero_footprint');
   });
 
   it('should return undefined for a nonexistent id', () => {
@@ -199,48 +358,80 @@ describe('selectContract', () => {
     expect(CONTRACT_POOL).toContain(result);
   });
 
-  it('should return from the full pool when excludeId is undefined', () => {
-    // Verify all contracts are reachable — mock random to hit each index
-    const ids = CONTRACT_POOL.map(c => c.id);
-    CONTRACT_POOL.forEach((_, i) => {
-      vi.spyOn(Math, 'random').mockReturnValueOnce(i / CONTRACT_POOL.length);
-      const result = selectContract(undefined);
-      expect(ids).toContain(result.id);
-    });
+  it('should return a contract from the basic pool (runsCompleted=0) when no excludeId', () => {
+    const basicIds = ['ghost_protocol', 'data_harvest', 'blitz'];
+    const result = selectContract(undefined, 0);
+    expect(basicIds).toContain(result.id);
   });
 
-  it('should return from the full pool when excludeId does not match any contract', () => {
-    // A nonexistent excludeId still leaves the eligible pool = full pool
-    const result = selectContract('does_not_exist');
+  it('should not return locked contracts when runsCompleted is 0', () => {
+    const lockedIds = [
+      'scorched_earth',
+      'clean_sweep',
+      'inside_job',
+      'paper_trail',
+      'dark_corridor',
+      'board_exposure',
+      'zero_footprint',
+    ];
+    for (let i = 0; i < 50; i++) {
+      const result = selectContract(undefined, 0);
+      expect(lockedIds).not.toContain(result.id);
+    }
+  });
+
+  it('should include run-3 contracts when runsCompleted is 1', () => {
+    const midPoolIds = [
+      'ghost_protocol',
+      'data_harvest',
+      'blitz',
+      'scorched_earth',
+      'clean_sweep',
+      'inside_job',
+    ];
+    const results = new Set<string>();
+    for (let i = 0; i < 200; i++) results.add(selectContract(undefined, 1).id);
+    // All 6 mid-pool contracts should be reachable
+    for (const id of midPoolIds) expect(results).toContain(id);
+    // Run-4-only contracts should not appear
+    expect(results).not.toContain('paper_trail');
+    expect(results).not.toContain('dark_corridor');
+  });
+
+  it('should return any of the 10 contracts when runsCompleted is 3 (full pool)', () => {
+    const results = new Set<string>();
+    for (let i = 0; i < 300; i++) results.add(selectContract(undefined, 3).id);
+    expect(results.size).toBe(10);
+  });
+
+  it('should return from the base pool when excludeId does not match any contract', () => {
+    const result = selectContract('does_not_exist', 0);
     expect(CONTRACT_POOL).toContain(result);
   });
 
-  it('should fall back to the full pool when excludeId would exclude all eligible contracts (single-element pool simulation)', () => {
-    // We can't reduce the real pool to 1 entry without modifying source, but we CAN
-    // verify the fallback branch: the only way eligible.length === 0 with the real pool
-    // is impossible (5 contracts, only 1 excluded). Verify the fallback is at least
-    // consistent by checking that with any valid excludeId the returned contract is
-    // still from CONTRACT_POOL (i.e. pool fallback yields a valid result).
-    const result = selectContract('ghost_protocol');
+  it('should fall back to the unlocked pool when excludeId would exclude all eligible contracts', () => {
+    // With runsCompleted=0 the base pool has 3 contracts. Excluding all 3 individually is
+    // impossible via a single excludeId, so verify the fallback: excluding a nonexistent ID
+    // still yields a valid contract from the basic pool.
+    const result = selectContract('nonexistent', 0);
     expect(result).toBeDefined();
     expect(typeof result.id).toBe('string');
   });
 
   it('should use Math.random to pick from the eligible pool', () => {
-    // With ghost_protocol excluded the eligible pool has 4 contracts (indices 0–3).
-    // Mock Math.random → 0 to deterministically pick the first eligible contract.
+    // With ghost_protocol excluded and runsCompleted=0, the eligible basic pool has 2
+    // contracts: [data_harvest, blitz]. Math.random → 0 picks index 0 → data_harvest.
     vi.spyOn(Math, 'random').mockReturnValue(0);
-    const result = selectContract('ghost_protocol');
-    // First eligible contract (ghost_protocol excluded) is data_harvest (index 1 in pool → index 0 eligible).
+    const result = selectContract('ghost_protocol', 0);
     expect(result.id).toBe('data_harvest');
   });
 
   it('should return contracts with different ids across multiple calls (randomness exercised)', () => {
     const results = new Set<string>();
     for (let i = 0; i < 100; i++) {
-      results.add(selectContract().id);
+      results.add(selectContract(undefined, 3).id);
     }
-    // With 5 contracts and 100 trials, we expect to see more than 1 distinct result
+    // With 10 contracts and 100 trials, expect multiple distinct results
     expect(results.size).toBeGreaterThan(1);
   });
 });

--- a/src/data/contracts.test.ts
+++ b/src/data/contracts.test.ts
@@ -418,6 +418,13 @@ describe('selectContract', () => {
     expect(typeof result.id).toBe('string');
   });
 
+  it('should fall back to the full CONTRACT_POOL when runsCompleted filters out all contracts', () => {
+    // runsCompleted = -1 makes unlocked = [] (all contracts have unlockedAfterRun >= 0),
+    // triggering the CONTRACT_POOL fallback on the base assignment.
+    const result = selectContract(undefined, -1);
+    expect(CONTRACT_POOL).toContain(result);
+  });
+
   it('should use Math.random to pick from the eligible pool', () => {
     // With ghost_protocol excluded and runsCompleted=0, the eligible basic pool has 2
     // contracts: [data_harvest, blitz]. Math.random → 0 picks index 0 → data_harvest.

--- a/src/data/contracts.test.ts
+++ b/src/data/contracts.test.ts
@@ -358,13 +358,16 @@ describe('selectContract', () => {
     expect(CONTRACT_POOL).toContain(result);
   });
 
-  it('should return a contract from the basic pool (runsCompleted=0) when no excludeId', () => {
+  it('should return only basic-pool contracts on the first contracted run (runsCompleted=1)', () => {
+    // runsCompleted=1 is the smallest value App.tsx passes (gate is runsCompleted > 0).
+    // With < semantics: unlockedAfterRun=0 → 0 < 1 ✓, unlockedAfterRun=1 → 1 < 1 ✗
     const basicIds = ['ghost_protocol', 'data_harvest', 'blitz'];
-    const result = selectContract(undefined, 0);
-    expect(basicIds).toContain(result.id);
+    for (let i = 0; i < 50; i++) {
+      expect(basicIds).toContain(selectContract(undefined, 1).id);
+    }
   });
 
-  it('should not return locked contracts when runsCompleted is 0', () => {
+  it('should not return locked contracts when runsCompleted is 1', () => {
     const lockedIds = [
       'scorched_earth',
       'clean_sweep',
@@ -375,12 +378,13 @@ describe('selectContract', () => {
       'zero_footprint',
     ];
     for (let i = 0; i < 50; i++) {
-      const result = selectContract(undefined, 0);
+      const result = selectContract(undefined, 1);
       expect(lockedIds).not.toContain(result.id);
     }
   });
 
-  it('should include run-3 contracts when runsCompleted is 1', () => {
+  it('should include run-3 contracts when runsCompleted is 2', () => {
+    // unlockedAfterRun=1 → 1 < 2 ✓ — mid-pool unlocks for run 3
     const midPoolIds = [
       'ghost_protocol',
       'data_harvest',
@@ -390,8 +394,7 @@ describe('selectContract', () => {
       'inside_job',
     ];
     const results = new Set<string>();
-    for (let i = 0; i < 200; i++) results.add(selectContract(undefined, 1).id);
-    // All 6 mid-pool contracts should be reachable
+    for (let i = 0; i < 200; i++) results.add(selectContract(undefined, 2).id);
     for (const id of midPoolIds) expect(results).toContain(id);
     // Run-4-only contracts should not appear
     expect(results).not.toContain('paper_trail');
@@ -399,37 +402,37 @@ describe('selectContract', () => {
   });
 
   it('should return any of the 10 contracts when runsCompleted is 3 (full pool)', () => {
+    // unlockedAfterRun=2 → 2 < 3 ✓ — full pool available from run 4
     const results = new Set<string>();
     for (let i = 0; i < 300; i++) results.add(selectContract(undefined, 3).id);
     expect(results.size).toBe(10);
   });
 
   it('should return from the base pool when excludeId does not match any contract', () => {
-    const result = selectContract('does_not_exist', 0);
+    const result = selectContract('does_not_exist', 1);
     expect(CONTRACT_POOL).toContain(result);
   });
 
   it('should fall back to the unlocked pool when excludeId would exclude all eligible contracts', () => {
-    // With runsCompleted=0 the base pool has 3 contracts. Excluding all 3 individually is
-    // impossible via a single excludeId, so verify the fallback: excluding a nonexistent ID
-    // still yields a valid contract from the basic pool.
-    const result = selectContract('nonexistent', 0);
+    // With runsCompleted=1 the base pool has 3 contracts. Excluding a nonexistent ID
+    // leaves the eligible pool unchanged — verifies the fallback path is consistent.
+    const result = selectContract('nonexistent', 1);
     expect(result).toBeDefined();
     expect(typeof result.id).toBe('string');
   });
 
   it('should fall back to the full CONTRACT_POOL when runsCompleted filters out all contracts', () => {
-    // runsCompleted = -1 makes unlocked = [] (all contracts have unlockedAfterRun >= 0),
-    // triggering the CONTRACT_POOL fallback on the base assignment.
-    const result = selectContract(undefined, -1);
+    // runsCompleted=0 with < semantics: no contract has unlockedAfterRun < 0,
+    // so unlocked=[] → triggers the CONTRACT_POOL fallback.
+    const result = selectContract(undefined, 0);
     expect(CONTRACT_POOL).toContain(result);
   });
 
   it('should use Math.random to pick from the eligible pool', () => {
-    // With ghost_protocol excluded and runsCompleted=0, the eligible basic pool has 2
+    // With ghost_protocol excluded and runsCompleted=1, the eligible basic pool has 2
     // contracts: [data_harvest, blitz]. Math.random → 0 picks index 0 → data_harvest.
     vi.spyOn(Math, 'random').mockReturnValue(0);
-    const result = selectContract('ghost_protocol', 0);
+    const result = selectContract('ghost_protocol', 1);
     expect(result.id).toBe('data_harvest');
   });
 

--- a/src/data/contracts.ts
+++ b/src/data/contracts.ts
@@ -37,8 +37,12 @@ export const TOOL_REGISTRY: Record<ToolId, Tool> = {
   },
 };
 
-// ── Contract pool (run 2+) ─────────────────────────────────
+// ── Contract pool ──────────────────────────────────────────
+// unlockedAfterRun: 0 → available from run 2 (first contracted run)
+//                   1 → available from run 3
+//                   2 → available from run 4 (full pool)
 export const CONTRACT_POOL: ContractDefinition[] = [
+  // ── Run 2+ (basic pool) ────────────────────────────────
   {
     id: 'ghost_protocol',
     title: 'GHOST PROTOCOL',
@@ -48,6 +52,7 @@ export const CONTRACT_POOL: ContractDefinition[] = [
     loadout: { exploitCharges: 2, startingTools: ['port-scanner', 'exploit-kit', 'spoof-id'] },
     networkVariant: 'standard',
     objectiveCondition: { type: 'trace_cap', maxTrace: 50 },
+    unlockedAfterRun: 0,
   },
   {
     id: 'data_harvest',
@@ -58,6 +63,7 @@ export const CONTRACT_POOL: ContractDefinition[] = [
     loadout: { exploitCharges: 3, startingTools: ['port-scanner', 'exploit-kit'] },
     networkVariant: 'standard',
     objectiveCondition: { type: 'exfil_count', minCount: 3 },
+    unlockedAfterRun: 0,
   },
   {
     id: 'blitz',
@@ -68,7 +74,10 @@ export const CONTRACT_POOL: ContractDefinition[] = [
     loadout: { exploitCharges: 5, startingTools: ['port-scanner', 'exploit-kit'] },
     networkVariant: 'standard',
     objectiveCondition: { type: 'no_burn' },
+    unlockedAfterRun: 0,
   },
+
+  // ── Run 3+ (mid pool) ──────────────────────────────────
   {
     id: 'scorched_earth',
     title: 'SCORCHED EARTH',
@@ -81,6 +90,7 @@ export const CONTRACT_POOL: ContractDefinition[] = [
     },
     networkVariant: 'standard',
     objectiveCondition: { type: 'exfil_count', minCount: 5 },
+    unlockedAfterRun: 1,
   },
   {
     id: 'clean_sweep',
@@ -94,6 +104,87 @@ export const CONTRACT_POOL: ContractDefinition[] = [
     },
     networkVariant: 'standard',
     objectiveCondition: { type: 'trace_cap', maxTrace: 40 },
+    unlockedAfterRun: 1,
+  },
+  {
+    id: 'inside_job',
+    title: 'INSIDE JOB',
+    brief:
+      "Someone inside IronGate's security team has opened a window — brief, deniable, and closing soon. Use the access while it lasts and pull whatever you can on their internal contacts.",
+    objectiveDescription:
+      "Exfiltrate the HR employee roster to expose IronGate's security division personnel.",
+    loadout: {
+      exploitCharges: 3,
+      startingTools: ['port-scanner', 'exploit-kit'],
+      startingCredentials: ['cred_sec_analyst'],
+    },
+    networkVariant: 'standard',
+    objectiveCondition: { type: 'identify_employee', divisionId: 'security' },
+    unlockedAfterRun: 1,
+    rewardOnComplete: 'SECURITY_INSIDER_IDENTIFIED',
+  },
+
+  // ── Run 4+ (full pool) ─────────────────────────────────
+  {
+    id: 'paper_trail',
+    title: 'PAPER TRAIL',
+    brief:
+      "The Q4 wire transfer records tell a story IronGate would rather keep buried. Our client needs them unredacted. The files are encrypted — come prepared, or don't come at all.",
+    objectiveDescription: 'Exfiltrate the Q4 wire transfer records from the finance database.',
+    loadout: {
+      exploitCharges: 3,
+      startingTools: ['port-scanner', 'exploit-kit', 'decryptor'],
+    },
+    networkVariant: 'standard',
+    objectiveCondition: { type: 'exfil_file', targetFileName: 'wire_transfers_q4.csv' },
+    unlockedAfterRun: 2,
+    rewardOnComplete: 'WIRE_TRANSFERS_OBTAINED',
+  },
+  {
+    id: 'dark_corridor',
+    title: 'DARK CORRIDOR',
+    brief:
+      "IronGate's security division runs its own counter-intelligence operation. We have reason to believe this channel is being monitored. Avoid their network entirely — find another path to your objective.",
+    objectiveDescription:
+      'Complete the run without compromising any node in the security division.',
+    loadout: { exploitCharges: 4, startingTools: ['port-scanner', 'exploit-kit'] },
+    networkVariant: 'standard',
+    objectiveCondition: { type: 'avoid_division', divisionId: 'security' },
+    unlockedAfterRun: 2,
+    rewardOnComplete: 'SECURITY_BYPASSED',
+  },
+  {
+    id: 'board_exposure',
+    title: 'BOARD EXPOSURE',
+    brief:
+      "IronGate's board has been authorising operations they cannot legally sanction — and they kept minutes. The legal division has the documentation. Extract it before the next external audit erases it.",
+    objectiveDescription:
+      'Exfiltrate the October board meeting minutes from the executive legal node.',
+    loadout: {
+      exploitCharges: 5,
+      startingTools: ['port-scanner', 'exploit-kit'],
+    },
+    networkVariant: 'standard',
+    objectiveCondition: { type: 'exfil_file', targetFileName: 'board_minutes_oct.pdf' },
+    unlockedAfterRun: 2,
+    rewardOnComplete: 'BOARD_EXPOSED',
+  },
+  {
+    id: 'zero_footprint',
+    title: 'ZERO FOOTPRINT',
+    brief:
+      "Our client has a specific interest in IronGate's finance personnel — names, clearance levels, access patterns. The HR records are the only source that covers all of them. Pull it clean and get out.",
+    objectiveDescription:
+      "Exfiltrate the HR employee roster to expose IronGate's finance division personnel.",
+    loadout: {
+      exploitCharges: 3,
+      startingTools: ['port-scanner', 'exploit-kit'],
+      startingCredentials: ['cred_fin_analyst'],
+    },
+    networkVariant: 'standard',
+    objectiveCondition: { type: 'identify_employee', divisionId: 'finance' },
+    unlockedAfterRun: 2,
+    rewardOnComplete: 'FINANCE_PERSONNEL_IDENTIFIED',
   },
 ];
 
@@ -102,11 +193,19 @@ export const getContract = (id: string): ContractDefinition | undefined =>
   CONTRACT_POOL.find(c => c.id === id);
 
 /**
- * Pick a random contract from the pool, optionally excluding one by ID.
- * Falls back to a random contract from the full pool if all are excluded (edge case with pool of 1).
+ * Pick a random contract from the pool.
+ *
+ * @param excludeId - Contract ID to exclude (e.g. the one just completed).
+ * @param runsCompleted - Number of completed runs from the dossier; filters out contracts
+ *   whose `unlockedAfterRun` exceeds this value. Defaults to 0 (basic pool only).
+ *
+ * Falls back to the unfiltered eligible pool if all unlocked contracts are excluded,
+ * and to the full pool if the unlocked pool itself is empty (should not happen in practice).
  */
-export const selectContract = (excludeId?: string): ContractDefinition => {
-  const eligible = excludeId ? CONTRACT_POOL.filter(c => c.id !== excludeId) : CONTRACT_POOL;
-  const pool = eligible.length > 0 ? eligible : CONTRACT_POOL;
+export const selectContract = (excludeId?: string, runsCompleted = 0): ContractDefinition => {
+  const unlocked = CONTRACT_POOL.filter(c => (c.unlockedAfterRun ?? 0) <= runsCompleted);
+  const base = unlocked.length > 0 ? unlocked : CONTRACT_POOL;
+  const eligible = excludeId ? base.filter(c => c.id !== excludeId) : base;
+  const pool = eligible.length > 0 ? eligible : base;
   return pool[Math.floor(Math.random() * pool.length)];
 };

--- a/src/data/contracts.ts
+++ b/src/data/contracts.ts
@@ -206,6 +206,8 @@ export const selectContract = (excludeId?: string, runsCompleted = 0): ContractD
   const unlocked = CONTRACT_POOL.filter(c => (c.unlockedAfterRun ?? 0) <= runsCompleted);
   const base = unlocked.length > 0 ? unlocked : CONTRACT_POOL;
   const eligible = excludeId ? base.filter(c => c.id !== excludeId) : base;
+  // c8 ignore next — eligible is only empty when a single excludeId matches every contract
+  // in base, which cannot happen with a pool of ≥ 2 contracts.
   const pool = eligible.length > 0 ? eligible : base;
   return pool[Math.floor(Math.random() * pool.length)];
 };

--- a/src/data/contracts.ts
+++ b/src/data/contracts.ts
@@ -38,9 +38,9 @@ export const TOOL_REGISTRY: Record<ToolId, Tool> = {
 };
 
 // ── Contract pool ──────────────────────────────────────────
-// unlockedAfterRun: 0 → available from run 2 (first contracted run)
-//                   1 → available from run 3
-//                   2 → available from run 4 (full pool)
+// unlockedAfterRun: 0 → available from run 2 onward  (runsCompleted=1 → 0 < 1 ✓)
+//                   1 → available from run 3 onward  (runsCompleted=2 → 1 < 2 ✓)
+//                   2 → available from run 4 onward  (runsCompleted=3 → 2 < 3 ✓)
 export const CONTRACT_POOL: ContractDefinition[] = [
   // ── Run 2+ (basic pool) ────────────────────────────────
   {
@@ -196,14 +196,17 @@ export const getContract = (id: string): ContractDefinition | undefined =>
  * Pick a random contract from the pool.
  *
  * @param excludeId - Contract ID to exclude (e.g. the one just completed).
- * @param runsCompleted - Number of completed runs from the dossier; filters out contracts
- *   whose `unlockedAfterRun` exceeds this value. Defaults to 0 (basic pool only).
+ * @param runsCompleted - Number of completed runs from the dossier (`dossier.runsCompleted`).
+ *   A contract with `unlockedAfterRun: N` enters the pool when `N < runsCompleted`, so:
+ *   - runsCompleted=1 (run 2): only level-0 contracts
+ *   - runsCompleted=2 (run 3): level 0+1
+ *   - runsCompleted=3 (run 4): full pool
+ *   Defaults to 1 (the smallest value App.tsx passes) to avoid accidentally showing an empty pool.
  *
- * Falls back to the unfiltered eligible pool if all unlocked contracts are excluded,
- * and to the full pool if the unlocked pool itself is empty (should not happen in practice).
+ * Falls back to the full pool if the unlocked pool is empty (guard against bad runsCompleted input).
  */
-export const selectContract = (excludeId?: string, runsCompleted = 0): ContractDefinition => {
-  const unlocked = CONTRACT_POOL.filter(c => (c.unlockedAfterRun ?? 0) <= runsCompleted);
+export const selectContract = (excludeId?: string, runsCompleted = 1): ContractDefinition => {
+  const unlocked = CONTRACT_POOL.filter(c => (c.unlockedAfterRun ?? 0) < runsCompleted);
   const base = unlocked.length > 0 ? unlocked : CONTRACT_POOL;
   const eligible = excludeId ? base.filter(c => c.id !== excludeId) : base;
   // c8 ignore next — eligible is only empty when a single excludeId matches every contract

--- a/src/data/divisionSeeds.ts
+++ b/src/data/divisionSeeds.ts
@@ -1,9 +1,20 @@
-import type { DivisionSeed } from '../types/divisionSeed';
+import type { DivisionId, DivisionSeed } from '../types/divisionSeed';
 
 // ── Division Seeds ──────────────────────────────────────────
 // Static configuration read by the Phase 4 procedural node generator.
 // ariaInfluenceRate values per spec §6.3: 0.3 / 0.2 / 0.1 / 0.25 / 0.4
 // fillerTemplates weights must sum to 1.0 per division.
+
+// ── Division → layer mapping ────────────────────────────────
+// Single source of truth for division→network-layer relationships.
+// Used by buildCredentialChains.ts (node generation) and App.tsx (avoid_division evaluation).
+export const DIVISION_LAYER: Readonly<Record<DivisionId, number>> = {
+  external_perimeter: 0,
+  operations: 1,
+  security: 2,
+  finance: 3,
+  executive: 4,
+} as const;
 
 export const DIVISION_SEEDS: DivisionSeed[] = [
   {

--- a/src/engine/buildCredentialChains.ts
+++ b/src/engine/buildCredentialChains.ts
@@ -1,18 +1,10 @@
 import type { LiveNode, GameFile, Credential } from '../types/game';
 import type { Employee } from '../types/employee';
-import type { DivisionId } from '../types/divisionSeed';
-import { DIVISION_SEEDS } from '../data/divisionSeeds';
+import { DIVISION_LAYER, DIVISION_SEEDS } from '../data/divisionSeeds';
 import { createPRNG } from './prng';
 
-// ── Division → layer mapping (mirrors generateFillerNodes) ──
-// Exported so test files can import rather than duplicate it.
-export const DIVISION_LAYER: Record<DivisionId, number> = {
-  external_perimeter: 0,
-  operations: 1,
-  security: 2,
-  finance: 3,
-  executive: 4,
-};
+// Re-exported so existing consumers (test files, App.tsx) don't need immediate updates.
+export { DIVISION_LAYER };
 
 // ── Public result type ──────────────────────────────────────
 

--- a/src/engine/commands.test.ts
+++ b/src/engine/commands.test.ts
@@ -3123,6 +3123,161 @@ describe('resolveCommand — contract objective detection', () => {
       expect((result.nextState as GameState).flags['contract_cap_exceeded']).toBeFalsy();
     });
   });
+
+  // ── exfil_file ────────────────────────────────────────────
+
+  describe('exfil_file contract', () => {
+    it('should set objectiveComplete = true when the target file is exfiltrated', async () => {
+      const state = produce(createInitialState(), s => {
+        s.network.nodes['contractor_portal']!.accessLevel = 'user';
+        s.contract = {
+          id: 'paper_trail',
+          networkVariant: 'standard',
+          objectiveComplete: false,
+          objectiveCondition: { type: 'exfil_file', targetFileName: 'welcome.txt' },
+        };
+      });
+      const result = await resolveCommand('exfil welcome.txt', state);
+      expect((result.nextState as GameState).contract?.objectiveComplete).toBe(true);
+    });
+
+    it('should append an objective complete system line when the target file is exfiltrated', async () => {
+      const state = produce(createInitialState(), s => {
+        s.network.nodes['contractor_portal']!.accessLevel = 'user';
+        s.contract = {
+          id: 'paper_trail',
+          networkVariant: 'standard',
+          objectiveComplete: false,
+          objectiveCondition: { type: 'exfil_file', targetFileName: 'welcome.txt' },
+        };
+      });
+      const result = await resolveCommand('exfil welcome.txt', state);
+      const completeLine = result.lines.find(l => l.content.includes('objective complete'));
+      expect(completeLine).toBeDefined();
+      expect(completeLine?.type).toBe('system');
+    });
+
+    it('should include the target file name in the objective complete message', async () => {
+      const state = produce(createInitialState(), s => {
+        s.network.nodes['contractor_portal']!.accessLevel = 'user';
+        s.contract = {
+          id: 'paper_trail',
+          networkVariant: 'standard',
+          objectiveComplete: false,
+          objectiveCondition: { type: 'exfil_file', targetFileName: 'welcome.txt' },
+        };
+      });
+      const result = await resolveCommand('exfil welcome.txt', state);
+      const completeLine = result.lines.find(l => l.content.includes('welcome.txt'));
+      expect(completeLine).toBeDefined();
+    });
+
+    it('should NOT set objectiveComplete when a different file is exfiltrated', async () => {
+      const state = produce(createInitialState(), s => {
+        s.network.nodes['contractor_portal']!.accessLevel = 'user';
+        s.contract = {
+          id: 'paper_trail',
+          networkVariant: 'standard',
+          objectiveComplete: false,
+          objectiveCondition: { type: 'exfil_file', targetFileName: 'other_file.txt' },
+        };
+      });
+      const result = await resolveCommand('exfil welcome.txt', state);
+      expect((result.nextState as GameState).contract?.objectiveComplete).toBe(false);
+    });
+
+    it('should NOT fire a second time when objectiveComplete is already true', async () => {
+      const state = produce(createInitialState(), s => {
+        s.network.nodes['contractor_portal']!.accessLevel = 'user';
+        // File already in exfiltrated (simulates prior exfil that triggered completion)
+        s.player.exfiltrated.push({
+          name: 'welcome.txt',
+          path: '/var/www/contractor/welcome.txt',
+          type: 'document',
+          content: 'already done',
+          exfiltrable: true,
+          accessRequired: 'user',
+        });
+        s.contract = {
+          id: 'paper_trail',
+          networkVariant: 'standard',
+          objectiveComplete: true,
+          objectiveCondition: { type: 'exfil_file', targetFileName: 'welcome.txt' },
+        };
+      });
+      // Exfil a different file — prevNames already includes welcome.txt so no re-trigger
+      const result = await resolveCommand('exfil welcome.txt', state);
+      const objectiveLines = result.lines.filter(l => l.content.includes('objective complete'));
+      expect(objectiveLines).toHaveLength(0);
+    });
+  });
+
+  // ── identify_employee ─────────────────────────────────────
+
+  describe('identify_employee contract', () => {
+    it('should set objectiveComplete = true when employee_roster.csv is exfiltrated', async () => {
+      // employee_roster.csv lives on ops_hr_db; connect there and get user access
+      const state = produce(createInitialState(), s => {
+        s.network.currentNodeId = 'ops_hr_db';
+        s.network.nodes['ops_hr_db']!.accessLevel = 'user';
+        s.contract = {
+          id: 'inside_job',
+          networkVariant: 'standard',
+          objectiveComplete: false,
+          objectiveCondition: { type: 'identify_employee', divisionId: 'security' },
+        };
+      });
+      const result = await resolveCommand('exfil employee_roster.csv', state);
+      expect((result.nextState as GameState).contract?.objectiveComplete).toBe(true);
+    });
+
+    it('should append an objective complete system line when employee_roster.csv is exfiltrated', async () => {
+      const state = produce(createInitialState(), s => {
+        s.network.currentNodeId = 'ops_hr_db';
+        s.network.nodes['ops_hr_db']!.accessLevel = 'user';
+        s.contract = {
+          id: 'inside_job',
+          networkVariant: 'standard',
+          objectiveComplete: false,
+          objectiveCondition: { type: 'identify_employee', divisionId: 'security' },
+        };
+      });
+      const result = await resolveCommand('exfil employee_roster.csv', state);
+      const completeLine = result.lines.find(l => l.content.includes('objective complete'));
+      expect(completeLine).toBeDefined();
+      expect(completeLine?.type).toBe('system');
+    });
+
+    it('should include the divisionId in the objective complete message', async () => {
+      const state = produce(createInitialState(), s => {
+        s.network.currentNodeId = 'ops_hr_db';
+        s.network.nodes['ops_hr_db']!.accessLevel = 'user';
+        s.contract = {
+          id: 'inside_job',
+          networkVariant: 'standard',
+          objectiveComplete: false,
+          objectiveCondition: { type: 'identify_employee', divisionId: 'security' },
+        };
+      });
+      const result = await resolveCommand('exfil employee_roster.csv', state);
+      const completeLine = result.lines.find(l => l.content.includes('security'));
+      expect(completeLine).toBeDefined();
+    });
+
+    it('should NOT set objectiveComplete when a non-roster file is exfiltrated', async () => {
+      const state = produce(createInitialState(), s => {
+        s.network.nodes['contractor_portal']!.accessLevel = 'user';
+        s.contract = {
+          id: 'inside_job',
+          networkVariant: 'standard',
+          objectiveComplete: false,
+          objectiveCondition: { type: 'identify_employee', divisionId: 'security' },
+        };
+      });
+      const result = await resolveCommand('exfil welcome.txt', state);
+      expect((result.nextState as GameState).contract?.objectiveComplete).toBe(false);
+    });
+  });
 });
 
 describe('createInitialState defaults', () => {

--- a/src/engine/commands.test.ts
+++ b/src/engine/commands.test.ts
@@ -3205,7 +3205,7 @@ describe('resolveCommand — contract objective detection', () => {
           objectiveCondition: { type: 'exfil_file', targetFileName: 'welcome.txt' },
         };
       });
-      // Exfil a different file — prevNames already includes welcome.txt so no re-trigger
+      // Re-exfil the same file — prevNames already includes welcome.txt so no re-trigger
       const result = await resolveCommand('exfil welcome.txt', state);
       const objectiveLines = result.lines.filter(l => l.content.includes('objective complete'));
       expect(objectiveLines).toHaveLength(0);

--- a/src/engine/commands.ts
+++ b/src/engine/commands.ts
@@ -344,7 +344,12 @@ const THRESHOLD_ALERT_META: Record<
  *   - trace_cap: notify when trace newly crosses the cap (sets a flag so the
  *     message fires exactly once per violation).
  *   - exfil_count: set objectiveComplete = true when the exfil target is reached.
+ *   - exfil_file: set objectiveComplete = true when the specific file is exfiltrated.
+ *   - identify_employee: set objectiveComplete = true when the employee_roster.csv is
+ *     exfiltrated (the roster is the only cross-division employee attribution source).
+ *     NOTE: per-division attribution requires tracking source-node on GameFile — deferred.
  *   - no_burn: detected in App.tsx at the burn-retry boundary; nothing to do here.
+ *   - avoid_division: evaluated at run-end in App.tsx; nothing to do here.
  */
 const applyObjectiveEffects = (prevState: GameState, result: CommandOutput): CommandOutput => {
   const nextState = result.nextState as GameState | undefined;
@@ -384,6 +389,44 @@ const applyObjectiveEffects = (prevState: GameState, result: CommandOutput): Com
       alertLines.push(
         sep(),
         sys(`// CONTRACT: objective complete — ${String(condition.minCount)} file(s) exfiltrated`),
+        sep(),
+      );
+      mutated = produce(mutated, s => {
+        if (s.contract) s.contract.objectiveComplete = true;
+      });
+    }
+  } else if (condition.type === 'exfil_file') {
+    const prevNames = prevState.player.exfiltrated.map(f => f.name);
+    const nextNames = nextState.player.exfiltrated.map(f => f.name);
+    if (
+      !contract.objectiveComplete &&
+      !prevNames.includes(condition.targetFileName) &&
+      nextNames.includes(condition.targetFileName)
+    ) {
+      alertLines.push(
+        sep(),
+        sys(`// CONTRACT: objective complete — '${condition.targetFileName}' exfiltrated`),
+        sep(),
+      );
+      mutated = produce(mutated, s => {
+        if (s.contract) s.contract.objectiveComplete = true;
+      });
+    }
+  } else if (condition.type === 'identify_employee') {
+    // Proxy check: the employee roster is the only file that covers all division personnel.
+    const EMPLOYEE_ROSTER = 'employee_roster.csv';
+    const prevNames = prevState.player.exfiltrated.map(f => f.name);
+    const nextNames = nextState.player.exfiltrated.map(f => f.name);
+    if (
+      !contract.objectiveComplete &&
+      !prevNames.includes(EMPLOYEE_ROSTER) &&
+      nextNames.includes(EMPLOYEE_ROSTER)
+    ) {
+      alertLines.push(
+        sep(),
+        sys(
+          `// CONTRACT: objective complete — employee records for '${condition.divisionId}' obtained`,
+        ),
         sep(),
       );
       mutated = produce(mutated, s => {

--- a/src/engine/commands.ts
+++ b/src/engine/commands.ts
@@ -414,6 +414,8 @@ const applyObjectiveEffects = (prevState: GameState, result: CommandOutput): Com
     }
   } else if (condition.type === 'identify_employee') {
     // Proxy check: the employee roster is the only file that covers all division personnel.
+    // TODO: filter by condition.divisionId once GameFile.sourceNodeId exists — currently
+    // all identify_employee contracts complete on the same file regardless of target division.
     const EMPLOYEE_ROSTER = 'employee_roster.csv';
     const prevNames = prevState.player.exfiltrated.map(f => f.name);
     const nextNames = nextState.player.exfiltrated.map(f => f.name);

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -1,3 +1,5 @@
+import type { DivisionId } from './divisionSeed';
+
 // ── Access levels ──────────────────────────────────────────
 export type AccessLevel = 'none' | 'user' | 'admin' | 'root';
 
@@ -222,8 +224,8 @@ export type ObjectiveCondition =
   | { type: 'exfil_count'; minCount: number }
   | { type: 'no_burn' }
   | { type: 'exfil_file'; targetFileName: string }
-  | { type: 'identify_employee'; divisionId: string }
-  | { type: 'avoid_division'; divisionId: string };
+  | { type: 'identify_employee'; divisionId: DivisionId }
+  | { type: 'avoid_division'; divisionId: DivisionId };
 
 export interface ContractDefinition {
   id: string;
@@ -239,7 +241,8 @@ export interface ContractDefinition {
   objectiveCondition: ObjectiveCondition;
   /** Run index after which this contract enters the pool (0 = available from run 2 onward). */
   unlockedAfterRun?: number;
-  /** Lore fragment key added to the dossier when this contract's objective is completed. */
+  /** Lore fragment key added to the dossier when this contract's objective is completed.
+   * TODO(phase-7): read this field after objectiveComplete flips and write the key to the dossier. */
   rewardOnComplete?: string;
 }
 

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -220,7 +220,10 @@ export interface SentinelState {
 export type ObjectiveCondition =
   | { type: 'trace_cap'; maxTrace: number }
   | { type: 'exfil_count'; minCount: number }
-  | { type: 'no_burn' };
+  | { type: 'no_burn' }
+  | { type: 'exfil_file'; targetFileName: string }
+  | { type: 'identify_employee'; divisionId: string }
+  | { type: 'avoid_division'; divisionId: string };
 
 export interface ContractDefinition {
   id: string;
@@ -234,6 +237,10 @@ export interface ContractDefinition {
   };
   networkVariant: string;
   objectiveCondition: ObjectiveCondition;
+  /** Run index after which this contract enters the pool (0 = available from run 2 onward). */
+  unlockedAfterRun?: number;
+  /** Lore fragment key added to the dossier when this contract's objective is completed. */
+  rewardOnComplete?: string;
 }
 
 /** Runtime contract state stored in GameState. */


### PR DESCRIPTION
## Summary

**Types & Data (`src/types/game.ts`, `src/data/contracts.ts`)**
- Extended `ObjectiveCondition` with three new variants: `exfil_file`, `identify_employee`, and `avoid_division`
- Added `unlockedAfterRun?: number` and `rewardOnComplete?: string` to `ContractDefinition`
- Authored 5 new contracts — inside_job, paper_trail, dark_corridor, board_exposure, zero_footprint — covering all objective types and all loadout variants (Standard, Heavy, Ghost, Insider, Equipped)
- Pool now has 10 contracts on a 3-tier unlock progression: 3 at run 2, +3 at run 3, full 10 at run 4

**Engine (`src/engine/commands.ts`)**
- `applyObjectiveEffects` now handles `exfil_file` (checks for specific file name in exfil list) and `identify_employee` (proxy check via `employee_roster.csv`; per-division attribution deferred — requires `GameFile.sourceNodeId` infra)
- `avoid_division` evaluated at run-end in `App.tsx` via layer↔divisionId map, consistent with the existing `no_burn`/`trace_cap` end-of-run pattern

**App (`src/App.tsx`)**
- All `selectContract` call sites updated to pass `dossier.runsCompleted` so the unlock gate is respected in production

Closes #31

## Test plan
- [x] Unit tests pass (1361/1361, all new objective types covered)
- [x] Typecheck passes (`tsc -b`)
- [x] ESLint clean
- [x] Smoke test: data-only changes verified through unit tests; E2E contract screen requires completing run 1 which cannot be automated in a short dev-server session

## Known limitations
- `identify_employee` uses `employee_roster.csv` as a universal proxy — per-division file attribution requires adding a `sourceNodeId` field to `GameFile` (deferred to a separate ticket)
- `avoid_division` maps division IDs to layers via a hardcoded local lookup; adding a new division requires updating both `divisionSeeds.ts` and the `DIVISION_LAYER` map in `App.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>