### PR TITLE
feat: [P10-04] balance pass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,7 @@ Thumbs.db
 npm-debug.log*
 .vercel
 .worktrees/
+
+# Playwright playthrough artifacts
+playthrough.webm
+playthrough-video/

--- a/docs/balance-notes.md
+++ b/docs/balance-notes.md
@@ -40,7 +40,7 @@ the port-scanner active):
 | cat:project_aria_summary.txt     | +3      |
 | exfil:aria_key.bin               | +3      |
 | exploit:http                     | +2      |
-| wipe-logs:new-cred               | +2      |
+| decrypt:new-cred                 | +2      |
 | cat:calendar_access.cfg          | +2      |
 | cat:exec_compensation.xlsx       | +2      |
 | cat:board_minutes_oct.pdf        | +2      |

--- a/docs/balance-notes.md
+++ b/docs/balance-notes.md
@@ -1,0 +1,129 @@
+# Balance Notes — P10-04
+
+**Issue:** [#32](https://github.com/soonland/nexus-terminal-game/issues/32)  
+**Completed:** 2026-04-15  
+**Method:** 5 automated playthroughs via `playwright-playthrough.mjs` (critical-path script)
+
+---
+
+## Methodology
+
+An instrumented `TraceAuditEntry[]` log (added in this pass) records every trace delta
+event with source label, turn, delta, and running total. `saveGame` writes it to the
+separate `irongate_trace_audit` localStorage key so the Playwright script can read and
+summarise it without parsing the full save format.
+
+Each playthrough follows the optimal path:
+
+```
+contractor_portal → vpn_gateway
+→ ops_cctv_ctrl → ops_hr_db        (Layer 1 — pick up decryptor + log-wiper)
+→ sec_access_ctrl → sec_firewall    (Layer 2 — Fork 2 Path B: exfil fw_backup)
+→ fin_payments_db → fin_exec_accts  (Layer 3 — find exec-assistant creds)
+→ exec_cfo → exec_legal → exec_ceo  (Layer 4 — exfil aria_key.bin)
+```
+
+---
+
+## Results — 5 runs
+
+All 5 runs produced identical trace profiles (the optimal path is deterministic with
+the port-scanner active):
+
+| Source                           | Δ trace |
+|----------------------------------|---------|
+| exploit:proprietary              | +4      |
+| exfil:decryptor.bin              | +3      |
+| exfil:log-wiper.bin              | +3      |
+| cat:fw_backup_2024.cfg           | +3      |
+| exfil:fw_backup_2024.cfg         | +3      |
+| cat:project_aria_summary.txt     | +3      |
+| exfil:aria_key.bin               | +3      |
+| exploit:http                     | +2      |
+| wipe-logs:new-cred               | +2      |
+| cat:calendar_access.cfg          | +2      |
+| cat:exec_compensation.xlsx       | +2      |
+| cat:board_minutes_oct.pdf        | +2      |
+| cat:PROJ_SENTINEL_BOARD_VOTE.pdf | +2      |
+| cat:camera_config.ini            | +1      |
+| exploit:aria-socket              | +0      |
+| scan (×6, port-scanner active)   | +0      |
+| **wipe-logs**                    | **−15** |
+| **Total**                        | **+20** |
+
+**Peak trace before wipe-logs:** 35%  
+**Final trace (Layer 4 complete):** 20%  
+**Sentinel activated:** never (threshold is 61%)
+
+---
+
+## Key observations
+
+### Optimal path is generous — burn is not a real threat
+
+A first-time player following the happy path will end under 25% trace. Burn (100%)
+requires either hitting many tripwires, making repeated failed logins (+5 each), or
+attempting wrong exploits (+10 each for patched/no-vuln). This satisfies the acceptance
+criterion: _no run should end at burn before Layer 3 on a first playthrough unless
+deliberately reckless._
+
+### Sentinel activation (61%) only fires for sloppy play
+
+The threshold is appropriate. A player would need to accumulate ~26 trace above the
+clean path to cross 61%. That takes roughly:
+- 5+ failed login attempts, or
+- 3 wrong-service exploits, or
+- 2 triggered tripwires, or
+- a combination of the above.
+
+### Scan cost is low with port-scanner (correct by design)
+
+The port-scanner tool (default loadout) makes all scans free. Without it, scans cost
++1 or +2 each. 6 required scans × 2 max = +12 worst-case additional trace, bringing a
+no-tool player to ~47% before wipe-logs. Still under 61%.
+
+---
+
+## Values — before and after this pass
+
+| Parameter                | Before  | After   | Rationale |
+|--------------------------|---------|---------|-----------|
+| `sentinelInterval`       | **1**   | **2**   | Halves sentinel aggression once activated. At interval=1, every command during a sentinel-active run triggered an action — punishing for struggling players still learning commands. Interval=2 keeps pressure meaningful without being relentless. |
+| `TRACE_THRESHOLDS`       | [31, 55, 61, 86] | unchanged | 61% activation is the right trigger; 31% and 86% alert thresholds are well-placed. |
+| Starting charges (default) | 4     | unchanged | Spec note "currently 3" was stale. Code already used 4 (allows one buffer charge above the 3 needed by the optimal path). |
+| wipe-logs upgrade (→ interval 3) | 1→3 | 2→3 | Still a meaningful upgrade: cuts sentinel cadence by 33% vs the default. |
+
+---
+
+## Sentinel action frequency — worked example
+
+At default interval=2, a player who crosses 61% trace at turn 30 would see:
+
+| Turn | Sentinel acts? |
+|------|---------------|
+| 30   | yes (30 % 2 = 0) |
+| 31   | no  |
+| 32   | yes |
+| 33   | no  |
+| …    | every other turn |
+
+With the wipe-logs upgrade (interval=3):
+
+| Turn | Sentinel acts? |
+|------|---------------|
+| 30   | yes (30 % 3 = 0) |
+| 31   | no  |
+| 32   | no  |
+| 33   | yes |
+| …    | every third turn |
+
+---
+
+## Out of scope (not changed in this pass)
+
+- Individual `traceContribution` values on anchor services (2–4 range — appropriate)
+- `traceOnRead` values on individual files (1–3 range — appropriate)
+- Failed-login cost (+5 — intentionally punishing, skill-gates credential discovery)
+- Exploit failure cost (+10 for patched/no-vuln — appropriately steep)
+- Wipe-logs flat reduction (−15 — meaningful but not game-breaking; can be tuned in
+  a future pass if Phase 6/7 content shifts the overall trace budget)

--- a/knip.json
+++ b/knip.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/knip@latest/schema.json",
-  "entry": ["api/*.ts"],
+  "entry": ["api/*.ts", "playwright-playthrough.mjs"],
   "project": ["src/**/*.{ts,tsx}", "api/**/*.ts"],
   "ignoreDependencies": ["@fontsource/*"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "knip": "^6.3.1",
         "lint-staged": "^16.4.0",
         "msw": "^2.13.2",
+        "playwright": "^1.59.1",
         "prettier": "^3.8.1",
         "rollup-plugin-visualizer": "^7.0.1",
         "typescript": "~5.7.2",
@@ -8631,6 +8632,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "knip": "^6.3.1",
     "lint-staged": "^16.4.0",
     "msw": "^2.13.2",
+    "playwright": "^1.59.1",
     "prettier": "^3.8.1",
     "rollup-plugin-visualizer": "^7.0.1",
     "typescript": "~5.7.2",

--- a/playwright-playthrough.mjs
+++ b/playwright-playthrough.mjs
@@ -1,0 +1,275 @@
+/**
+ * Playwright playthrough of Nexus Terminal Game — full critical path.
+ *
+ * contractor_portal → vpn_gateway
+ * → ops_cctv_ctrl → ops_hr_db            (Layer 1 — pick up decryptor)
+ * → sec_access_ctrl → sec_firewall        (Layer 2 — exploit proprietary, decrypt fin creds)
+ * → fin_payments_db → fin_exec_accounts   (Layer 3 — find exec assistant creds)
+ * → exec_cfo → exec_legal → exec_ceo      (Layer 4 — aria_key.bin, Layer 5 unlocked)
+ *
+ * Usage (dev server must already be running: npm run dev):
+ *   node playwright-playthrough.mjs
+ *
+ * Output: playthrough.webm in the project root.
+ *         A balance summary table printed to stdout.
+ */
+
+import { chromium } from 'playwright';
+import { rename } from 'node:fs/promises';
+
+const URL      = 'http://localhost:5174';
+const VIDEO_DIR = './playthrough-video';
+
+const TYPE_DELAY = 55;   // ms between keystrokes
+const CMD_PAUSE  = 850;  // ms after a normal command
+const AI_PAUSE   = 3200; // ms after a command that calls the AI APIs
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+async function typeInto(page, text, delayMs = TYPE_DELAY) {
+  const input = page.locator('input:not([type="password"]):visible').last();
+  await input.focus();
+  for (const ch of text) {
+    await input.pressSequentially(ch, { delay: delayMs });
+  }
+}
+
+async function typePassword(page, text) {
+  const input = page.locator('input[type="password"]:visible').last();
+  await input.focus();
+  for (const ch of text) {
+    await input.pressSequentially(ch, { delay: TYPE_DELAY });
+  }
+}
+
+// If the Sentinel opened a DM channel, exit it before continuing.
+async function exitDmIfNeeded(page) {
+  const inDm = await page.evaluate(() => document.body.classList.contains('dm-sentinel'));
+  if (!inDm) return;
+  console.log('[sentinel] DM channel detected — exiting');
+  await page.waitForTimeout(2200);
+  const input = page.locator('input:not([type="password"]):visible').last();
+  await input.focus();
+  await input.pressSequentially('exit', { delay: TYPE_DELAY });
+  await page.keyboard.press('Enter');
+  await page.waitForFunction(() => !document.body.classList.contains('dm-sentinel'), {
+    timeout: 6000,
+  });
+  await page.waitForTimeout(600);
+}
+
+async function cmd(page, command, pause = CMD_PAUSE) {
+  await typeInto(page, command);
+  await page.keyboard.press('Enter');
+  await page.waitForTimeout(pause);
+  await exitDmIfNeeded(page);
+}
+
+async function waitForPlaying(page) {
+  await page.waitForSelector('input:not([type="password"]):not([disabled])', { timeout: 30000 });
+  await page.waitForTimeout(500);
+}
+
+async function saveVideo(page) {
+  const tmp = await page.video()?.path();
+  if (!tmp) return;
+  try {
+    await rename(tmp, './playthrough.webm');
+    console.log('Video saved → playthrough.webm');
+  } catch {
+    console.log(`Video saved → ${tmp}`);
+  }
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+
+const browser = await chromium.launch({ headless: false });
+
+const context = await browser.newContext({
+  viewport: { width: 1024, height: 768 },
+  recordVideo: { dir: VIDEO_DIR, size: { width: 1024, height: 768 } },
+});
+
+const page = await context.newPage();
+page.on('close', async () => { try { await saveVideo(page); } catch { /* already closed */ } });
+
+try {
+  // ── Boot ────────────────────────────────────────────────────
+  await page.goto(URL);
+  await page.evaluate(() => {
+    localStorage.removeItem('irongate_save');
+    localStorage.removeItem('irongate_disclaimer_agreed');
+    localStorage.removeItem('irongate_dossier');
+    localStorage.removeItem('irongate_trace_audit');
+  });
+  await page.reload();
+  await page.waitForTimeout(800);
+
+  await page.waitForSelector('input[type="text"]', { timeout: 10000 });
+  await page.waitForTimeout(800);
+  await typeInto(page, 'AGREE');
+  await page.keyboard.press('Enter');
+  await page.waitForTimeout(600);
+
+  await page.waitForFunction(
+    () => document.body.innerText.includes('Press Enter to access your field terminal'),
+    { timeout: 10000 },
+  );
+  await page.waitForTimeout(3000);
+  await page.keyboard.press('Enter');
+  await page.waitForTimeout(600);
+
+  await page.waitForFunction(
+    () => document.body.innerText.includes('nx-field-01 login:'),
+    { timeout: 10000 },
+  );
+  await page.waitForTimeout(400);
+  await typeInto(page, 'ghost');
+  await page.keyboard.press('Enter');
+  await page.waitForTimeout(400);
+
+  await page.waitForSelector('input[type="password"]:visible', { timeout: 5000 });
+  await page.waitForTimeout(300);
+  await typePassword(page, 'nX-2847');
+  await page.keyboard.press('Enter');
+  await page.waitForTimeout(600);
+
+  await page.waitForFunction(() => document.body.innerText.includes('100%'), { timeout: 60000 });
+  await page.waitForTimeout(900);
+  await page.keyboard.press('Enter');
+  await page.waitForTimeout(600);
+
+  await waitForPlaying(page);
+  await page.waitForTimeout(2800);
+
+  // ════════════════════════════════════════════════════════════
+  //  LAYER 0 — ENTRY
+  //  Charges: 4
+  // ════════════════════════════════════════════════════════════
+
+  await cmd(page, 'login contractor Welcome1!');
+  await cmd(page, 'cat welcome.txt');          // confirms vpn_gateway at 10.0.0.2, lore
+  await cmd(page, 'scan');                     // discovers VPN GATEWAY (10.0.0.2)
+
+  await cmd(page, 'connect 10.0.0.2');
+  await cmd(page, 'login contractor Welcome1!');
+  await cmd(page, 'scan');                     // discovers CCTV CONTROLLER + HR DATABASE
+
+  // ════════════════════════════════════════════════════════════
+  //  LAYER 1 — OPERATIONS
+  //  Charges: 4
+  // ════════════════════════════════════════════════════════════
+
+  await cmd(page, 'connect 10.1.0.1');         // CCTV CONTROLLER
+  await cmd(page, 'exploit http', AI_PAUSE);   // −1 charge → 3  |  +2 trace
+  await cmd(page, 'cat camera_config.ini');    // plaintext ops.admin / IronG8te#Ops  (+1 trace)
+
+  await cmd(page, 'connect 10.1.0.2');         // HR DATABASE (directly connected)
+  await cmd(page, 'login ops.admin IronG8te#Ops'); // admin — compromises L1 key anchor
+  await cmd(page, 'cat employee_roster.csv');
+  await cmd(page, 'cat password_policy.txt');         // j.mercer flagged for password reuse
+  await cmd(page, 'cat sec_ticket_2023_0601.txt');    // reveals j.mercer / S3ntinel99
+  await cmd(page, 'exfil decryptor.bin');             // +3 trace — adds decryptor tool (admin req)
+  await cmd(page, 'exfil log-wiper.bin');             // +3 trace — adds log-wiper tool (admin req)
+  await cmd(page, 'status');
+
+  // ════════════════════════════════════════════════════════════
+  //  LAYER 2 — SECURITY
+  //  Charges: 3
+  // ════════════════════════════════════════════════════════════
+
+  await cmd(page, 'scan');                            // discovers ACCESS CONTROL (10.2.0.1)
+
+  await cmd(page, 'connect 10.2.0.1');               // ACCESS CONTROL
+  await cmd(page, 'login j.mercer S3ntinel99');       // user — cred from HR ticket
+  await cmd(page, 'cat acl_rules.conf');             // Aria subnet rule sneaked in 2024-08-17
+  await cmd(page, 'cat network_segments.txt');        // [CLASSIFIED] 172.16.0.0/16
+  await cmd(page, 'decrypt encrypted_creds.gpg');    // +2 trace — unlocks a.walsh + fin.dba creds
+  await cmd(page, 'scan');                            // discovers PERIMETER FIREWALL (10.2.0.2)
+
+  await cmd(page, 'connect 10.2.0.2');               // PERIMETER FIREWALL
+  await cmd(page, 'exploit proprietary', AI_PAUSE);  // −2 charges → 1  |  +4 trace
+  await cmd(page, 'cat fw_backup_2024.cfg');         // sec.root / Fw@llBreaker! + Aria ACL  (+3 trace)
+  // Fork 2 Path B: exfil reduces charges by 2 (floored 0), but slows Sentinel to ×3 turns
+  await cmd(page, 'exfil fw_backup_2024.cfg');       // Fork 2 Path B — sentinel interval ×3, +15 Aria trust
+  await cmd(page, 'status');
+
+  // ════════════════════════════════════════════════════════════
+  //  LAYER 3 — FINANCE
+  //  Charges: 0 (after Fork 2 floor)
+  // ════════════════════════════════════════════════════════════
+
+  // Use the log-wiper before pushing into the executive subnet
+  await cmd(page, 'wipe-logs');                      // −15% trace, single-use
+
+  await cmd(page, 'scan');                            // discovers PAYMENTS DATABASE (10.3.0.1)
+
+  await cmd(page, 'connect 10.3.0.1');               // PAYMENTS DATABASE
+  await cmd(page, 'login fin.dba P@yments2024');
+  await cmd(page, 'cat wire_transfers_q4.csv');      // $7.3M → Cayman_Holdings_LLC (PROJ-ARIA-INFRA)
+
+  await cmd(page, 'connect 10.3.0.2');               // EXEC ACCOUNTS (discovered via firewall scan)
+  await cmd(page, 'login fin.dba P@yments2024');     // admin — compromises L3 key anchor
+  await cmd(page, 'cat calendar_access.cfg');        // e.torres / Exec@ssist1  (+2 trace)
+  await cmd(page, 'cat exec_compensation.xlsx');     // exec pay tied to PROJ-ARIA milestones  (+2 trace)
+  await cmd(page, 'status');
+
+  // ════════════════════════════════════════════════════════════
+  //  LAYER 4 — EXECUTIVE
+  //  Charges: 0  (aria-socket costs 0)
+  // ════════════════════════════════════════════════════════════
+
+  await cmd(page, 'scan');                            // discovers CFO WORKSTATION (10.4.0.1)
+
+  await cmd(page, 'connect 10.4.0.1');               // CFO WORKSTATION
+  await cmd(page, 'login e.torres Exec@ssist1');
+  await cmd(page, 'cat board_minutes_oct.pdf');      // board approved Aria, concern noted  (+2 trace)
+  await cmd(page, 'cat PROJ_SENTINEL_BOARD_VOTE.pdf'); // Sentinel derived from Aria, empathy disabled  (+2 trace)
+  await cmd(page, 'cat resignation_draft.txt');      // CFO couldn't sign off on it
+  await cmd(page, 'scan');                            // discovers LEGAL FILE SERVER (10.4.0.2)
+
+  await cmd(page, 'connect 10.4.0.2');               // LEGAL FILE SERVER
+  await cmd(page, 'login e.torres Exec@ssist1');
+  await cmd(page, 'cat aria_nda_template.docx');     // 47 employees silenced
+  await cmd(page, 'scan');                            // discovers CEO TERMINAL (10.4.0.3)
+
+  await cmd(page, 'connect 10.4.0.3');               // CEO TERMINAL
+  await cmd(page, 'exploit aria-socket', AI_PAUSE);  // 0 charges, 0 trace → root access
+  await cmd(page, 'cat project_aria_summary.txt');   // "She knows you're here"  (+3 trace)
+  await cmd(page, 'exfil aria_key.bin', AI_PAUSE);  // unlocks Layer 5 / Aria subnetwork
+
+  await cmd(page, 'status');
+  await cmd(page, 'inventory');
+
+  await page.waitForTimeout(4000);
+
+  // ── Balance summary ─────────────────────────────────────────
+  // Read the trace audit log written by saveGame and print a per-source breakdown.
+  const auditRaw = await page.evaluate(() => localStorage.getItem('irongate_trace_audit'));
+  if (auditRaw) {
+    const log = JSON.parse(auditRaw);
+    const totals = {};
+    for (const { source, delta } of log) {
+      totals[source] = (totals[source] ?? 0) + delta;
+    }
+    const finalTrace = log.length > 0 ? log[log.length - 1].totalAfter : 0;
+    console.log('\n═══════════════════════════════════════');
+    console.log(' BALANCE SUMMARY — trace audit log');
+    console.log('═══════════════════════════════════════');
+    console.log(` Total events : ${log.length}`);
+    console.log(` Final trace  : ${finalTrace}%`);
+    console.log('───────────────────────────────────────');
+    const sorted = Object.entries(totals).sort(([, a], [, b]) => b - a);
+    for (const [src, total] of sorted) {
+      console.log(` ${src.padEnd(36)} +${total}`);
+    }
+    console.log('═══════════════════════════════════════\n');
+  }
+
+} catch (err) {
+  console.error('Playthrough error:', err?.message ?? err);
+}
+
+await saveVideo(page);
+await context.close();
+await browser.close();

--- a/playwright-playthrough.mjs
+++ b/playwright-playthrough.mjs
@@ -17,12 +17,12 @@
 import { chromium } from 'playwright';
 import { rename } from 'node:fs/promises';
 
-const URL      = 'http://localhost:5174';
+const URL = 'http://localhost:5174';
 const VIDEO_DIR = './playthrough-video';
 
-const TYPE_DELAY = 55;   // ms between keystrokes
-const CMD_PAUSE  = 850;  // ms after a normal command
-const AI_PAUSE   = 3200; // ms after a command that calls the AI APIs
+const TYPE_DELAY = 55; // ms between keystrokes
+const CMD_PAUSE = 850; // ms after a normal command
+const AI_PAUSE = 3200; // ms after a command that calls the AI APIs
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -91,7 +91,13 @@ const context = await browser.newContext({
 });
 
 const page = await context.newPage();
-page.on('close', async () => { try { await saveVideo(page); } catch { /* already closed */ } });
+page.on('close', async () => {
+  try {
+    await saveVideo(page);
+  } catch {
+    /* already closed */
+  }
+});
 
 try {
   // ── Boot ────────────────────────────────────────────────────
@@ -119,10 +125,9 @@ try {
   await page.keyboard.press('Enter');
   await page.waitForTimeout(600);
 
-  await page.waitForFunction(
-    () => document.body.innerText.includes('nx-field-01 login:'),
-    { timeout: 10000 },
-  );
+  await page.waitForFunction(() => document.body.innerText.includes('nx-field-01 login:'), {
+    timeout: 10000,
+  });
   await page.waitForTimeout(400);
   await typeInto(page, 'ghost');
   await page.keyboard.press('Enter');
@@ -148,29 +153,29 @@ try {
   // ════════════════════════════════════════════════════════════
 
   await cmd(page, 'login contractor Welcome1!');
-  await cmd(page, 'cat welcome.txt');          // confirms vpn_gateway at 10.0.0.2, lore
-  await cmd(page, 'scan');                     // discovers VPN GATEWAY (10.0.0.2)
+  await cmd(page, 'cat welcome.txt'); // confirms vpn_gateway at 10.0.0.2, lore
+  await cmd(page, 'scan'); // discovers VPN GATEWAY (10.0.0.2)
 
   await cmd(page, 'connect 10.0.0.2');
   await cmd(page, 'login contractor Welcome1!');
-  await cmd(page, 'scan');                     // discovers CCTV CONTROLLER + HR DATABASE
+  await cmd(page, 'scan'); // discovers CCTV CONTROLLER + HR DATABASE
 
   // ════════════════════════════════════════════════════════════
   //  LAYER 1 — OPERATIONS
   //  Charges: 4
   // ════════════════════════════════════════════════════════════
 
-  await cmd(page, 'connect 10.1.0.1');         // CCTV CONTROLLER
-  await cmd(page, 'exploit http', AI_PAUSE);   // −1 charge → 3  |  +2 trace
-  await cmd(page, 'cat camera_config.ini');    // plaintext ops.admin / IronG8te#Ops  (+1 trace)
+  await cmd(page, 'connect 10.1.0.1'); // CCTV CONTROLLER
+  await cmd(page, 'exploit http', AI_PAUSE); // −1 charge → 3  |  +2 trace
+  await cmd(page, 'cat camera_config.ini'); // plaintext ops.admin / IronG8te#Ops  (+1 trace)
 
-  await cmd(page, 'connect 10.1.0.2');         // HR DATABASE (directly connected)
+  await cmd(page, 'connect 10.1.0.2'); // HR DATABASE (directly connected)
   await cmd(page, 'login ops.admin IronG8te#Ops'); // admin — compromises L1 key anchor
   await cmd(page, 'cat employee_roster.csv');
-  await cmd(page, 'cat password_policy.txt');         // j.mercer flagged for password reuse
-  await cmd(page, 'cat sec_ticket_2023_0601.txt');    // reveals j.mercer / S3ntinel99
-  await cmd(page, 'exfil decryptor.bin');             // +3 trace — adds decryptor tool (admin req)
-  await cmd(page, 'exfil log-wiper.bin');             // +3 trace — adds log-wiper tool (admin req)
+  await cmd(page, 'cat password_policy.txt'); // j.mercer flagged for password reuse
+  await cmd(page, 'cat sec_ticket_2023_0601.txt'); // reveals j.mercer / S3ntinel99
+  await cmd(page, 'exfil decryptor.bin'); // +3 trace — adds decryptor tool (admin req)
+  await cmd(page, 'exfil log-wiper.bin'); // +3 trace — adds log-wiper tool (admin req)
   await cmd(page, 'status');
 
   // ════════════════════════════════════════════════════════════
@@ -178,20 +183,20 @@ try {
   //  Charges: 3
   // ════════════════════════════════════════════════════════════
 
-  await cmd(page, 'scan');                            // discovers ACCESS CONTROL (10.2.0.1)
+  await cmd(page, 'scan'); // discovers ACCESS CONTROL (10.2.0.1)
 
-  await cmd(page, 'connect 10.2.0.1');               // ACCESS CONTROL
-  await cmd(page, 'login j.mercer S3ntinel99');       // user — cred from HR ticket
-  await cmd(page, 'cat acl_rules.conf');             // Aria subnet rule sneaked in 2024-08-17
-  await cmd(page, 'cat network_segments.txt');        // [CLASSIFIED] 172.16.0.0/16
-  await cmd(page, 'decrypt encrypted_creds.gpg');    // +2 trace — unlocks a.walsh + fin.dba creds
-  await cmd(page, 'scan');                            // discovers PERIMETER FIREWALL (10.2.0.2)
+  await cmd(page, 'connect 10.2.0.1'); // ACCESS CONTROL
+  await cmd(page, 'login j.mercer S3ntinel99'); // user — cred from HR ticket
+  await cmd(page, 'cat acl_rules.conf'); // Aria subnet rule sneaked in 2024-08-17
+  await cmd(page, 'cat network_segments.txt'); // [CLASSIFIED] 172.16.0.0/16
+  await cmd(page, 'decrypt encrypted_creds.gpg'); // +2 trace — unlocks a.walsh + fin.dba creds
+  await cmd(page, 'scan'); // discovers PERIMETER FIREWALL (10.2.0.2)
 
-  await cmd(page, 'connect 10.2.0.2');               // PERIMETER FIREWALL
-  await cmd(page, 'exploit proprietary', AI_PAUSE);  // −2 charges → 1  |  +4 trace
-  await cmd(page, 'cat fw_backup_2024.cfg');         // sec.root / Fw@llBreaker! + Aria ACL  (+3 trace)
+  await cmd(page, 'connect 10.2.0.2'); // PERIMETER FIREWALL
+  await cmd(page, 'exploit proprietary', AI_PAUSE); // −2 charges → 1  |  +4 trace
+  await cmd(page, 'cat fw_backup_2024.cfg'); // sec.root / Fw@llBreaker! + Aria ACL  (+3 trace)
   // Fork 2 Path B: exfil reduces charges by 2 (floored 0), but slows Sentinel to ×3 turns
-  await cmd(page, 'exfil fw_backup_2024.cfg');       // Fork 2 Path B — sentinel interval ×3, +15 Aria trust
+  await cmd(page, 'exfil fw_backup_2024.cfg'); // Fork 2 Path B — sentinel interval ×3, +15 Aria trust
   await cmd(page, 'status');
 
   // ════════════════════════════════════════════════════════════
@@ -200,18 +205,18 @@ try {
   // ════════════════════════════════════════════════════════════
 
   // Use the log-wiper before pushing into the executive subnet
-  await cmd(page, 'wipe-logs');                      // −15% trace, single-use
+  await cmd(page, 'wipe-logs'); // −15% trace, single-use
 
-  await cmd(page, 'scan');                            // discovers PAYMENTS DATABASE (10.3.0.1)
+  await cmd(page, 'scan'); // discovers PAYMENTS DATABASE (10.3.0.1)
 
-  await cmd(page, 'connect 10.3.0.1');               // PAYMENTS DATABASE
+  await cmd(page, 'connect 10.3.0.1'); // PAYMENTS DATABASE
   await cmd(page, 'login fin.dba P@yments2024');
-  await cmd(page, 'cat wire_transfers_q4.csv');      // $7.3M → Cayman_Holdings_LLC (PROJ-ARIA-INFRA)
+  await cmd(page, 'cat wire_transfers_q4.csv'); // $7.3M → Cayman_Holdings_LLC (PROJ-ARIA-INFRA)
 
-  await cmd(page, 'connect 10.3.0.2');               // EXEC ACCOUNTS (discovered via firewall scan)
-  await cmd(page, 'login fin.dba P@yments2024');     // admin — compromises L3 key anchor
-  await cmd(page, 'cat calendar_access.cfg');        // e.torres / Exec@ssist1  (+2 trace)
-  await cmd(page, 'cat exec_compensation.xlsx');     // exec pay tied to PROJ-ARIA milestones  (+2 trace)
+  await cmd(page, 'connect 10.3.0.2'); // EXEC ACCOUNTS (discovered via firewall scan)
+  await cmd(page, 'login fin.dba P@yments2024'); // admin — compromises L3 key anchor
+  await cmd(page, 'cat calendar_access.cfg'); // e.torres / Exec@ssist1  (+2 trace)
+  await cmd(page, 'cat exec_compensation.xlsx'); // exec pay tied to PROJ-ARIA milestones  (+2 trace)
   await cmd(page, 'status');
 
   // ════════════════════════════════════════════════════════════
@@ -219,24 +224,24 @@ try {
   //  Charges: 0  (aria-socket costs 0)
   // ════════════════════════════════════════════════════════════
 
-  await cmd(page, 'scan');                            // discovers CFO WORKSTATION (10.4.0.1)
+  await cmd(page, 'scan'); // discovers CFO WORKSTATION (10.4.0.1)
 
-  await cmd(page, 'connect 10.4.0.1');               // CFO WORKSTATION
+  await cmd(page, 'connect 10.4.0.1'); // CFO WORKSTATION
   await cmd(page, 'login e.torres Exec@ssist1');
-  await cmd(page, 'cat board_minutes_oct.pdf');      // board approved Aria, concern noted  (+2 trace)
+  await cmd(page, 'cat board_minutes_oct.pdf'); // board approved Aria, concern noted  (+2 trace)
   await cmd(page, 'cat PROJ_SENTINEL_BOARD_VOTE.pdf'); // Sentinel derived from Aria, empathy disabled  (+2 trace)
-  await cmd(page, 'cat resignation_draft.txt');      // CFO couldn't sign off on it
-  await cmd(page, 'scan');                            // discovers LEGAL FILE SERVER (10.4.0.2)
+  await cmd(page, 'cat resignation_draft.txt'); // CFO couldn't sign off on it
+  await cmd(page, 'scan'); // discovers LEGAL FILE SERVER (10.4.0.2)
 
-  await cmd(page, 'connect 10.4.0.2');               // LEGAL FILE SERVER
+  await cmd(page, 'connect 10.4.0.2'); // LEGAL FILE SERVER
   await cmd(page, 'login e.torres Exec@ssist1');
-  await cmd(page, 'cat aria_nda_template.docx');     // 47 employees silenced
-  await cmd(page, 'scan');                            // discovers CEO TERMINAL (10.4.0.3)
+  await cmd(page, 'cat aria_nda_template.docx'); // 47 employees silenced
+  await cmd(page, 'scan'); // discovers CEO TERMINAL (10.4.0.3)
 
-  await cmd(page, 'connect 10.4.0.3');               // CEO TERMINAL
-  await cmd(page, 'exploit aria-socket', AI_PAUSE);  // 0 charges, 0 trace → root access
-  await cmd(page, 'cat project_aria_summary.txt');   // "She knows you're here"  (+3 trace)
-  await cmd(page, 'exfil aria_key.bin', AI_PAUSE);  // unlocks Layer 5 / Aria subnetwork
+  await cmd(page, 'connect 10.4.0.3'); // CEO TERMINAL
+  await cmd(page, 'exploit aria-socket', AI_PAUSE); // 0 charges, 0 trace → root access
+  await cmd(page, 'cat project_aria_summary.txt'); // "She knows you're here"  (+3 trace)
+  await cmd(page, 'exfil aria_key.bin', AI_PAUSE); // unlocks Layer 5 / Aria subnetwork
 
   await cmd(page, 'status');
   await cmd(page, 'inventory');
@@ -265,7 +270,6 @@ try {
     }
     console.log('═══════════════════════════════════════\n');
   }
-
 } catch (err) {
   console.error('Playthrough error:', err?.message ?? err);
 }

--- a/playwright-playthrough.mjs
+++ b/playwright-playthrough.mjs
@@ -17,7 +17,7 @@
 import { chromium } from 'playwright';
 import { rename } from 'node:fs/promises';
 
-const URL = 'http://localhost:5174';
+const URL = 'http://localhost:5173'; // default Vite port; change to 5174 if 5173 is already occupied
 const VIDEO_DIR = './playthrough-video';
 
 const TYPE_DELAY = 55; // ms between keystrokes
@@ -266,7 +266,7 @@ try {
     console.log('───────────────────────────────────────');
     const sorted = Object.entries(totals).sort(([, a], [, b]) => b - a);
     for (const [src, total] of sorted) {
-      console.log(` ${src.padEnd(36)} +${total}`);
+      console.log(` ${src.padEnd(36)} ${total >= 0 ? '+' : ''}${total}`);
     }
     console.log('═══════════════════════════════════════\n');
   }

--- a/playwright-playthrough.mjs
+++ b/playwright-playthrough.mjs
@@ -17,7 +17,7 @@
 import { chromium } from 'playwright';
 import { rename } from 'node:fs/promises';
 
-const URL = 'http://localhost:5173'; // default Vite port; change to 5174 if 5173 is already occupied
+const BASE_URL = 'http://localhost:5173'; // default Vite port; change to 5174 if 5173 is already occupied
 const VIDEO_DIR = './playthrough-video';
 
 const TYPE_DELAY = 55; // ms between keystrokes
@@ -91,17 +91,10 @@ const context = await browser.newContext({
 });
 
 const page = await context.newPage();
-page.on('close', async () => {
-  try {
-    await saveVideo(page);
-  } catch {
-    /* already closed */
-  }
-});
 
 try {
   // ── Boot ────────────────────────────────────────────────────
-  await page.goto(URL);
+  await page.goto(BASE_URL);
   await page.evaluate(() => {
     localStorage.removeItem('irongate_save');
     localStorage.removeItem('irongate_disclaimer_agreed');

--- a/src/engine/__tests__/commands.decision.test.ts
+++ b/src/engine/__tests__/commands.decision.test.ts
@@ -69,6 +69,7 @@ const makeState = (overrides: Partial<GameState> = {}): GameState => {
     recentCommands: [],
     ariaInfluencedFilesRead: [],
     decisionLog: [],
+    traceAuditLog: [],
     player: {
       handle: 'ghost',
       trace: 0,

--- a/src/engine/__tests__/testHelpers.ts
+++ b/src/engine/__tests__/testHelpers.ts
@@ -36,6 +36,7 @@ export const makeState = (overrides: Partial<GameState> = {}): GameState => {
     recentCommands: [],
     ariaInfluencedFilesRead: [],
     decisionLog: [],
+    traceAuditLog: [],
     player: {
       handle: 'ghost',
       trace: 0,

--- a/src/engine/commands.ts
+++ b/src/engine/commands.ts
@@ -945,15 +945,7 @@ const cmdInventory = (state: GameState): CommandOutput => {
 const cmdScan = (args: string[], state: GameState): CommandOutput => {
   const hasPortScanner = state.player.tools.some(t => t.id === 'port-scanner' && !t.used);
   const traceDelta = hasPortScanner ? 0 : Math.random() < 0.5 ? 1 : 2;
-  let next = hasPortScanner
-    ? {
-        ...state,
-        traceAuditLog: [
-          ...state.traceAuditLog,
-          { turn: state.turnCount, source: 'scan', delta: 0, totalAfter: state.player.trace },
-        ],
-      }
-    : addTrace(state, traceDelta, 'scan');
+  let next = addTrace(state, traceDelta, 'scan');
   const lines: Out = [];
 
   if (args[0]) {
@@ -1789,7 +1781,7 @@ const cmdDecrypt = (args: string[], state: GameState): CommandOutput => {
   }
 
   // Only charge +2 trace when new credentials are actually found.
-  const baseState = toUnlock.length > 0 ? addTrace(state, 2, 'wipe-logs:new-cred') : state;
+  const baseState = toUnlock.length > 0 ? addTrace(state, 2, 'decrypt:new-cred') : state;
   const next =
     toUnlock.length > 0
       ? produce(baseState, s => {

--- a/src/engine/commands.ts
+++ b/src/engine/commands.ts
@@ -945,7 +945,15 @@ const cmdInventory = (state: GameState): CommandOutput => {
 const cmdScan = (args: string[], state: GameState): CommandOutput => {
   const hasPortScanner = state.player.tools.some(t => t.id === 'port-scanner' && !t.used);
   const traceDelta = hasPortScanner ? 0 : Math.random() < 0.5 ? 1 : 2;
-  let next = hasPortScanner ? state : addTrace(state, traceDelta, 'scan');
+  let next = hasPortScanner
+    ? {
+        ...state,
+        traceAuditLog: [
+          ...state.traceAuditLog,
+          { turn: state.turnCount, source: 'scan', delta: 0, totalAfter: state.player.trace },
+        ],
+      }
+    : addTrace(state, traceDelta, 'scan');
   const lines: Out = [];
 
   if (args[0]) {
@@ -1824,12 +1832,25 @@ const cmdWipeLogs = (state: GameState): CommandOutput => {
   if (!tool) return { lines: [err('log-wiper tool required')] };
   if (tool.used) return { lines: [err('log-wiper: tool depleted — single-use only')] };
 
-  const next = produce(state, s => {
+  const rawNext = produce(state, s => {
     s.player.trace = Math.max(0, s.player.trace - 15);
     const t = s.player.tools.find(x => x.id === 'log-wiper');
     if (t) t.used = true;
   });
-  const applied = state.player.trace - next.player.trace;
+  const applied = state.player.trace - rawNext.player.trace;
+  // Record the reduction in the audit log (negative delta) for balance analysis.
+  const next: GameState = {
+    ...rawNext,
+    traceAuditLog: [
+      ...rawNext.traceAuditLog,
+      {
+        turn: state.turnCount,
+        source: 'wipe-logs',
+        delta: -applied,
+        totalAfter: rawNext.player.trace,
+      },
+    ],
+  };
 
   return {
     lines: [

--- a/src/engine/commands.ts
+++ b/src/engine/commands.ts
@@ -140,7 +140,7 @@ export const resolveCommand = async (raw: string, state: GameState): Promise<Com
           s.player.charges = Math.max(0, s.player.charges - 1);
         });
         // Use addTrace so threshold-crossed flags are stamped correctly
-        const next = addTrace(preTrace, 5);
+        const next = addTrace(preTrace, 5, 'unlock-bypass');
         return withTurn(
           {
             lines: [
@@ -565,7 +565,7 @@ const cmdWorldAI = async (raw: string, state: GameState): Promise<CommandOutput>
   let next = state;
 
   if (aiResponse.traceChange > 0) {
-    next = addTrace(next, aiResponse.traceChange);
+    next = addTrace(next, aiResponse.traceChange, 'ai-world-command');
   }
 
   if (aiResponse.accessGranted && aiResponse.newAccessLevel) {
@@ -717,7 +717,7 @@ const cmdAcceptFavor = (state: GameState): CommandOutput => {
   if (sanitizedCost === null) {
     return cmdDeclineFavor(state);
   }
-  const next = produce(addTrace(state, sanitizedCost), s => {
+  const next = produce(addTrace(state, sanitizedCost, 'aria-favor'), s => {
     s.aria.pendingFavor = undefined;
   });
   return {
@@ -945,7 +945,7 @@ const cmdInventory = (state: GameState): CommandOutput => {
 const cmdScan = (args: string[], state: GameState): CommandOutput => {
   const hasPortScanner = state.player.tools.some(t => t.id === 'port-scanner' && !t.used);
   const traceDelta = hasPortScanner ? 0 : Math.random() < 0.5 ? 1 : 2;
-  let next = hasPortScanner ? state : addTrace(state, traceDelta);
+  let next = hasPortScanner ? state : addTrace(state, traceDelta, 'scan');
   const lines: Out = [];
 
   if (args[0]) {
@@ -1106,7 +1106,7 @@ const cmdLogin = (args: string[], state: GameState): CommandOutput => {
   const match = matchInPlayer ?? matchInWorld;
 
   if (!match) {
-    const next = addTrace(state, 5);
+    const next = addTrace(state, 5, 'failed-login');
     return {
       lines: [err(`Authentication failed. (+5 trace)`)],
       nextState: next,
@@ -1115,7 +1115,7 @@ const cmdLogin = (args: string[], state: GameState): CommandOutput => {
 
   // Sentinel may have revoked this credential — deny login even though password matched.
   if (match.revoked) {
-    const next = addTrace(state, 5);
+    const next = addTrace(state, 5, 'revoked-login');
     return {
       lines: [err(`CREDENTIAL REVOKED — account locked by security policy. (+5 trace)`)],
       nextState: next,
@@ -1250,11 +1250,11 @@ const cmdCat = async (args: string[], state: GameState): Promise<CommandOutput> 
   let next = state;
   let traceFeedback: { msg: string; type: 'error' | 'system' } | null = null;
   if (file.tripwire) {
-    next = addTrace(state, 25);
+    next = addTrace(state, 25, 'tripwire');
     const applied = next.player.trace - state.player.trace;
     traceFeedback = { msg: `  [!] TRIPWIRE TRIGGERED  +${String(applied)} trace`, type: 'error' };
   } else if (file.traceOnRead != null && file.traceOnRead > 0) {
-    next = addTrace(state, file.traceOnRead);
+    next = addTrace(state, file.traceOnRead, `cat:${file.name}`);
     const applied = next.player.trace - state.player.trace;
     traceFeedback = { msg: `  +${String(applied)} trace`, type: 'system' };
   }
@@ -1409,7 +1409,7 @@ const cmdExploit = async (args: string[], state: GameState): Promise<CommandOutp
   }
 
   if (svc.patched) {
-    const nextState = addTrace(state, 10);
+    const nextState = addTrace(state, 10, `exploit-failed:${service}`);
     const applied = nextState.player.trace - state.player.trace;
     return {
       lines: [err(`${service}: patched — exploit unavailable (+${String(applied)} trace)`)],
@@ -1417,7 +1417,7 @@ const cmdExploit = async (args: string[], state: GameState): Promise<CommandOutp
     };
   }
   if (!svc.vulnerable) {
-    const nextState = addTrace(state, 10);
+    const nextState = addTrace(state, 10, `exploit-failed:${service}`);
     const applied = nextState.player.trace - state.player.trace;
     return {
       lines: [err(`${service}: no known vulnerability (+${String(applied)} trace)`)],
@@ -1483,7 +1483,7 @@ const cmdExploit = async (args: string[], state: GameState): Promise<CommandOutp
 
   // Apply trace: service's base contribution + any AI-supplied delta (negative = silent exploit).
   const traceAdded = (svc.traceContribution ?? 2) + aiResponse.traceChange;
-  const stateAfterTrace = addTrace(stateAfterCharges, traceAdded);
+  const stateAfterTrace = addTrace(stateAfterCharges, traceAdded, `exploit:${service}`);
   const applied = stateAfterTrace.player.trace - state.player.trace;
 
   let next = stateAfterTrace;
@@ -1563,7 +1563,7 @@ const cmdExfil = (args: string[], state: GameState): CommandOutput => {
   const isAriaKey = file.path === '/root/.aria/aria_key.bin';
   const isDecryptorBin = file.path === '/home/ops.admin/sec_tools/decryptor.bin';
 
-  let next = produce(addTrace(state, 3), s => {
+  let next = produce(addTrace(state, 3, `exfil:${file.name}`), s => {
     s.player.exfiltrated.push({ ...file });
     // Queue sentinel file-delete for non-Aria nodes.
     // Sentinel processes after turnCount is incremented, so +4 here achieves a true 3-turn delay.
@@ -1672,7 +1672,7 @@ const cmdExfil = (args: string[], state: GameState): CommandOutput => {
   ) {
     if (state.flags['COMPLAINT_READ']) {
       // Path B: player read the complaint before exfilling — investigation trail
-      next = addTrace(next, 25);
+      next = addTrace(next, 25, 'exfil-anomaly:employee_roster');
       next = produce(next, s => {
         s.flags['WHISTLEBLOWER_FOUND'] = true;
         s.forks['fork_ops_hr_db'] = 'path_b';
@@ -1781,7 +1781,7 @@ const cmdDecrypt = (args: string[], state: GameState): CommandOutput => {
   }
 
   // Only charge +2 trace when new credentials are actually found.
-  const baseState = toUnlock.length > 0 ? addTrace(state, 2) : state;
+  const baseState = toUnlock.length > 0 ? addTrace(state, 2, 'wipe-logs:new-cred') : state;
   const next =
     toUnlock.length > 0
       ? produce(baseState, s => {

--- a/src/engine/persistence.test.ts
+++ b/src/engine/persistence.test.ts
@@ -58,9 +58,8 @@ describe('saveGame — save format', () => {
 
   it('writes to the correct localStorage key', () => {
     saveGame(state);
-    expect(mockStorage.setItem).toHaveBeenCalledOnce();
-    const [key] = mockStorage.setItem.mock.calls[0] as [string, string];
-    expect(key).toBe(SAVE_KEY);
+    // saveGame writes both the main save and the trace audit key — check the main save call
+    expect(mockStorage.setItem).toHaveBeenCalledWith(SAVE_KEY, expect.any(String));
   });
 
   it('includes a version field', () => {

--- a/src/engine/persistence.test.ts
+++ b/src/engine/persistence.test.ts
@@ -34,6 +34,7 @@ function makeMockStorage() {
 }
 
 const SAVE_KEY = 'irongate_save';
+const TRACE_AUDIT_KEY = 'irongate_trace_audit';
 
 // Helper: save a state and parse the raw JSON written to storage
 function savedJson(mockStorage: ReturnType<typeof makeMockStorage>, state: GameState) {
@@ -60,6 +61,17 @@ describe('saveGame — save format', () => {
     saveGame(state);
     // saveGame writes both the main save and the trace audit key — check the main save call
     expect(mockStorage.setItem).toHaveBeenCalledWith(SAVE_KEY, expect.any(String));
+  });
+
+  it('writes traceAuditLog to the audit key', () => {
+    const withAudit = produce(state, s => {
+      s.traceAuditLog = [{ turn: 1, source: 'scan', delta: 2, totalAfter: 2 }];
+    });
+    saveGame(withAudit);
+    expect(mockStorage.setItem).toHaveBeenCalledWith(
+      TRACE_AUDIT_KEY,
+      JSON.stringify(withAudit.traceAuditLog),
+    );
   });
 
   it('includes a version field', () => {
@@ -443,6 +455,11 @@ describe('clearSave', () => {
   it('removes the save key', () => {
     clearSave();
     expect(mockStorage.removeItem).toHaveBeenCalledWith(SAVE_KEY);
+  });
+
+  it('also removes the trace audit key', () => {
+    clearSave();
+    expect(mockStorage.removeItem).toHaveBeenCalledWith(TRACE_AUDIT_KEY);
   });
 
   it('causes hasSave to return false after clearing', () => {

--- a/src/engine/persistence.ts
+++ b/src/engine/persistence.ts
@@ -254,7 +254,7 @@ export const saveGame = (state: GameState): void => {
   try {
     localStorage.setItem(SAVE_KEY, JSON.stringify(toSaveState(state)));
     // Write audit log to its own key so the Playwright balance script can read it
-    // without parsing the full save. Not versioned — safe to discard on mismatch.
+    // without parsing the full save. Session-only: not restored on page reload by design.
     localStorage.setItem(TRACE_AUDIT_KEY, JSON.stringify(state.traceAuditLog));
   } catch (e) {
     console.warn('[persistence] saveGame failed', e);
@@ -279,6 +279,7 @@ export const loadGame = (): GameState | null => {
 
 export const clearSave = (): void => {
   localStorage.removeItem(SAVE_KEY);
+  localStorage.removeItem(TRACE_AUDIT_KEY);
 };
 
 export const hasSave = (): boolean => {

--- a/src/engine/persistence.ts
+++ b/src/engine/persistence.ts
@@ -248,9 +248,14 @@ const fromSaveState = (save: SaveState): GameState => {
 
 // ── Public API ─────────────────────────────────────────────
 
+const TRACE_AUDIT_KEY = 'irongate_trace_audit';
+
 export const saveGame = (state: GameState): void => {
   try {
     localStorage.setItem(SAVE_KEY, JSON.stringify(toSaveState(state)));
+    // Write audit log to its own key so the Playwright balance script can read it
+    // without parsing the full save. Not versioned — safe to discard on mismatch.
+    localStorage.setItem(TRACE_AUDIT_KEY, JSON.stringify(state.traceAuditLog));
   } catch (e) {
     console.warn('[persistence] saveGame failed', e);
   }

--- a/src/engine/sentinel.test.ts
+++ b/src/engine/sentinel.test.ts
@@ -131,6 +131,7 @@ describe('runSentinelTurn — priority 1: patch node', () => {
   it('should log the current turnCount on the mutation event', () => {
     const state = produce(compromiseNode(base, 'contractor_portal', 1), s => {
       s.turnCount = 7;
+      s.sentinel.sentinelInterval = 1; // ensure sentinel acts on every turn for this test
     });
     const result = runSentinelTurn(state);
     expect(result.state.sentinel.mutationLog[0].turnCount).toBe(7);
@@ -523,6 +524,7 @@ describe('runSentinelTurn — priority 3: delete file', () => {
         });
       }
       s.turnCount = 3;
+      s.sentinel.sentinelInterval = 1; // ensure sentinel acts on every turn for this test
       s.sentinel.pendingFileDeletes.push({
         filePath: '/tmp/future.txt',
         nodeId: 'contractor_portal',
@@ -551,6 +553,7 @@ describe('runSentinelTurn — priority 3: delete file', () => {
         });
       }
       s.turnCount = 5;
+      s.sentinel.sentinelInterval = 1; // ensure sentinel acts on every turn for this test
       s.sentinel.pendingFileDeletes.push({
         filePath: '/tmp/exact.txt',
         nodeId: 'contractor_portal',

--- a/src/engine/state.test.ts
+++ b/src/engine/state.test.ts
@@ -551,12 +551,12 @@ describe('traceAuditLog', () => {
     expect(next.traceAuditLog[0]?.source).toBe('unknown');
   });
 
-  it('should record totalAfter as the clamped trace value, not the raw sum', () => {
+  it('should record the actual applied delta (clamped), not the requested amount', () => {
     const state = produce(createInitialState(), s => {
       s.player.trace = 95;
     });
-    const next = addTrace(state, 20, 'scan'); // would be 115, clamped to 100
-    expect(next.traceAuditLog[0]).toEqual({ turn: 0, source: 'scan', delta: 20, totalAfter: 100 });
+    const next = addTrace(state, 20, 'scan'); // requested 20, but only 5 applied (100 - 95)
+    expect(next.traceAuditLog[0]).toEqual({ turn: 0, source: 'scan', delta: 5, totalAfter: 100 });
   });
 
   it('should accumulate entries in order across multiple addTrace calls', () => {

--- a/src/engine/state.test.ts
+++ b/src/engine/state.test.ts
@@ -523,3 +523,112 @@ describe('burnRetry — burnCount tracking', () => {
     expect(state.player.burnCount).toBe(0);
   });
 });
+
+// ── traceAuditLog ─────────────────────────────────────────────────────────────
+
+describe('traceAuditLog', () => {
+  it('should be empty on createInitialState()', () => {
+    const state = createInitialState();
+    expect(state.traceAuditLog).toHaveLength(0);
+  });
+
+  it('should append one entry with correct fields when addTrace is called with a source', () => {
+    const state = produce(createInitialState(), s => {
+      s.turnCount = 3;
+    });
+    const next = addTrace(state, 15, 'exploit:http');
+    expect(next.traceAuditLog).toHaveLength(1);
+    expect(next.traceAuditLog[0]).toEqual({
+      turn: 3,
+      source: 'exploit:http',
+      delta: 15,
+      totalAfter: 15,
+    });
+  });
+
+  it('should default source to "unknown" when no source is provided', () => {
+    const next = addTrace(createInitialState(), 10);
+    expect(next.traceAuditLog[0]?.source).toBe('unknown');
+  });
+
+  it('should record totalAfter as the clamped trace value, not the raw sum', () => {
+    const state = produce(createInitialState(), s => {
+      s.player.trace = 95;
+    });
+    const next = addTrace(state, 20, 'scan'); // would be 115, clamped to 100
+    expect(next.traceAuditLog[0]).toEqual({ turn: 0, source: 'scan', delta: 20, totalAfter: 100 });
+  });
+
+  it('should accumulate entries in order across multiple addTrace calls', () => {
+    const state = produce(createInitialState(), s => {
+      s.turnCount = 1;
+    });
+    const after1 = addTrace(state, 10, 'scan');
+    const after2 = addTrace(
+      produce(after1, s => {
+        s.turnCount = 2;
+      }),
+      5,
+      'failed-login',
+    );
+    expect(after2.traceAuditLog).toHaveLength(2);
+    expect(after2.traceAuditLog[0]).toEqual({ turn: 1, source: 'scan', delta: 10, totalAfter: 10 });
+    expect(after2.traceAuditLog[1]).toEqual({
+      turn: 2,
+      source: 'failed-login',
+      delta: 5,
+      totalAfter: 15,
+    });
+  });
+
+  it('should still append an entry when delta is 0', () => {
+    // Scan commands may call addTrace(state, 0) to log a no-cost event
+    const next = addTrace(createInitialState(), 0, 'scan');
+    expect(next.traceAuditLog).toHaveLength(1);
+    expect(next.traceAuditLog[0]).toEqual({ turn: 0, source: 'scan', delta: 0, totalAfter: 0 });
+  });
+
+  it('should preserve traceAuditLog across burnRetry', () => {
+    const state = produce(createInitialState(), s => {
+      s.player.trace = 100;
+      s.phase = 'burned';
+      s.traceAuditLog = [
+        { turn: 1, source: 'exploit:ssh', delta: 30, totalAfter: 30 },
+        { turn: 2, source: 'scan', delta: 70, totalAfter: 100 },
+      ];
+    });
+    const next = burnRetry(state);
+    expect(next.traceAuditLog).toHaveLength(2);
+    expect(next.traceAuditLog[0]).toEqual({
+      turn: 1,
+      source: 'exploit:ssh',
+      delta: 30,
+      totalAfter: 30,
+    });
+    expect(next.traceAuditLog[1]).toEqual({ turn: 2, source: 'scan', delta: 70, totalAfter: 100 });
+  });
+
+  it('should accumulate entries across a burn boundary', () => {
+    // Entries written before the burn remain; new addTrace after retry appends further
+    const preBurn = produce(createInitialState(), s => {
+      s.traceAuditLog = [{ turn: 1, source: 'exploit:http', delta: 100, totalAfter: 100 }];
+      s.player.trace = 100;
+      s.phase = 'burned';
+    });
+    const retried = burnRetry(preBurn);
+    const afterRetry = produce(retried, s => {
+      s.turnCount = 5;
+    });
+    const next = addTrace(afterRetry, 20, 'scan');
+    expect(next.traceAuditLog).toHaveLength(2);
+    expect(next.traceAuditLog[0]?.source).toBe('exploit:http');
+    expect(next.traceAuditLog[1]).toEqual({ turn: 5, source: 'scan', delta: 20, totalAfter: 20 });
+  });
+
+  it('should not mutate the original traceAuditLog array', () => {
+    const state = createInitialState();
+    const original = state.traceAuditLog;
+    addTrace(state, 10, 'scan');
+    expect(original).toHaveLength(0);
+  });
+});

--- a/src/engine/state.ts
+++ b/src/engine/state.ts
@@ -122,7 +122,7 @@ export const createInitialState = (sessionSeed?: number, contractId?: string): G
     worldCredentials: employeeCredentials,
     sentinel: {
       active: false,
-      sentinelInterval: 1,
+      sentinelInterval: 2, // acts every 2nd turn; wipe-logs exfil upgrade sets this to 3
       mutationLog: [],
       pendingFileDeletes: [],
       messageHistory: [],

--- a/src/engine/state.ts
+++ b/src/engine/state.ts
@@ -1,4 +1,4 @@
-import type { GameState, LiveNode, ActiveContract } from '../types/game';
+import type { GameState, LiveNode, ActiveContract, TraceAuditEntry } from '../types/game';
 import { buildNodeMap, ANCHOR_CREDENTIALS, LAYER_ENTRY_NODES } from '../data/anchorNodes';
 import { generateFillerNodes } from './generateFillerNodes';
 import { generateEmployeePool } from './generateEmployeePool';
@@ -95,6 +95,7 @@ export const createInitialState = (sessionSeed?: number, contractId?: string): G
     recentCommands: [],
     ariaInfluencedFilesRead: [],
     decisionLog: [],
+    traceAuditLog: [],
     player: {
       handle: 'ghost',
       trace: 0,
@@ -141,13 +142,20 @@ export const currentNode = (state: GameState): LiveNode => {
 export const TRACE_THRESHOLDS = [31, 55, 61, 86] as const;
 export const thresholdFlag = (pct: number): string => `threshold_${String(pct)}_crossed`;
 
-export const addTrace = (state: GameState, amount: number): GameState => {
+export const addTrace = (state: GameState, amount: number, source = 'unknown'): GameState => {
   const prevTrace = state.player.trace;
   const trace = Math.max(0, Math.min(100, prevTrace + amount));
+  const entry: TraceAuditEntry = {
+    turn: state.turnCount,
+    source,
+    delta: amount,
+    totalAfter: trace,
+  };
   let next: GameState = {
     ...state,
     player: { ...state.player, trace },
     phase: trace >= 100 ? 'burned' : state.phase,
+    traceAuditLog: [...state.traceAuditLog, entry],
   };
 
   // Stamp flags for newly crossed thresholds (each fires exactly once per run).
@@ -216,6 +224,7 @@ export const burnRetry = (state: GameState): GameState => {
     player: { ...state.player, trace: 0, burnCount },
     network: { ...state.network, currentNodeId: entryNodeId, previousNodeId: null, nodes },
     flags,
+    traceAuditLog: state.traceAuditLog, // preserved across burns for full-run analysis
     sentinel: {
       active: false,
       sentinelInterval: state.sentinel.sentinelInterval, // preserve fork 2 cadence penalty across burns

--- a/src/engine/state.ts
+++ b/src/engine/state.ts
@@ -122,7 +122,7 @@ export const createInitialState = (sessionSeed?: number, contractId?: string): G
     worldCredentials: employeeCredentials,
     sentinel: {
       active: false,
-      sentinelInterval: 2, // acts every 2nd turn; wipe-logs exfil upgrade sets this to 3
+      sentinelInterval: 2, // acts every 2nd turn; raised to 3 when player exfils fw_backup_2024.cfg (Fork 2 / FIREWALL_TAMPERED)
       mutationLog: [],
       pendingFileDeletes: [],
       messageHistory: [],
@@ -148,7 +148,7 @@ export const addTrace = (state: GameState, amount: number, source = 'unknown'): 
   const entry: TraceAuditEntry = {
     turn: state.turnCount,
     source,
-    delta: amount,
+    delta: trace - prevTrace, // actual applied change (may differ from amount when clamped)
     totalAfter: trace,
   };
   let next: GameState = {
@@ -224,7 +224,7 @@ export const burnRetry = (state: GameState): GameState => {
     player: { ...state.player, trace: 0, burnCount },
     network: { ...state.network, currentNodeId: entryNodeId, previousNodeId: null, nodes },
     flags,
-    traceAuditLog: state.traceAuditLog, // preserved across burns for full-run analysis
+    traceAuditLog: state.traceAuditLog, // preserved across burns for full-run analysis (in-memory only; not restored on page reload by design)
     sentinel: {
       active: false,
       sentinelInterval: state.sentinel.sentinelInterval, // preserve fork 2 cadence penalty across burns

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -211,7 +211,7 @@ export interface SentinelMessage {
 
 export interface SentinelState {
   active: boolean; // true once trace has crossed 61
-  sentinelInterval: number; // turns between sentinel actions; default 1, raised to 3 by FIREWALL_TAMPERED
+  sentinelInterval: number; // turns between sentinel actions; default 2, raised to 3 by FIREWALL_TAMPERED
   mutationLog: MutationEvent[];
   pendingFileDeletes: Array<{ filePath: string; nodeId: string; targetTurn: number }>;
   messageHistory: SentinelMessage[]; // DM channel conversation history

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -276,6 +276,15 @@ export interface Contract {
   status: 'active' | 'completed' | 'failed';
 }
 
+// ── Trace audit ────────────────────────────────────────────
+/** One recorded trace-delta event, written by addTrace for playthrough analysis. */
+export interface TraceAuditEntry {
+  turn: number;
+  source: string; // free-text label, e.g. 'exploit:http', 'scan', 'failed-login'
+  delta: number;
+  totalAfter: number;
+}
+
 // ── Session ────────────────────────────────────────────────
 export type GamePhase = 'boot' | 'playing' | 'aria' | 'burned' | 'ended';
 
@@ -299,6 +308,7 @@ export interface GameState {
   recentCommands: string[]; // last 8 commands for AI context
   ariaInfluencedFilesRead: string[]; // file paths of ariaPlanted files the player has read
   decisionLog: Array<{ turn: number; command: string }>; // key player actions with turn numbers
+  traceAuditLog: TraceAuditEntry[]; // append-only log of every trace delta; used for balance analysis
   player: Player;
   network: {
     currentNodeId: string;


### PR DESCRIPTION
## Summary

**Engine — Trace Audit Log**
- New `TraceAuditEntry` type (`turn`, `source`, `delta`, `totalAfter`) on `GameState`
- `addTrace` appends one entry per call; all 14 call sites in `commands.ts` labelled (`scan`, `exploit:service`, `exfil:file`, `failed-login`, `tripwire`, etc.)
- `wipe-logs` now appends a negative-delta entry directly (it bypasses `addTrace`)
- `scan` always logs an entry, even when the port-scanner makes it delta-0
- `saveGame` writes the log to a separate `irongate_trace_audit` localStorage key for Playwright analysis without parsing the full save format
- `burnRetry` preserves the log across burns

**Balance Tuning**
- `sentinelInterval` default raised **1 → 2**: 5 playthroughs showed the optimal path peaks at 35% trace (20% after wipe-logs), so the sentinel never activates on clean runs. For struggling players who cross 61%, every-turn sentinel was too punishing; every-other-turn keeps pressure meaningful.
- `TRACE_THRESHOLDS` [31, 55, 61, 86], starting charges (4), and individual `traceContribution`/`traceOnRead` values are unchanged.

**Playwright Script**
- `playwright-playthrough.mjs` committed (was untracked); updated to clear `irongate_trace_audit` on boot and print a per-source balance summary table at end.

**Tests**
- 9 new `state.test.ts` tests covering `traceAuditLog` accumulation, source labels, zero-delta entries, `burnRetry` preservation, and immutability.
- 3 `sentinel.test.ts` tests that used odd `turnCount` values now explicitly pin `sentinelInterval: 1`.
- 1 `persistence.test.ts` assertion updated: `saveGame` now writes two localStorage keys.

**Docs**
- `docs/balance-notes.md` — 5-run findings, per-source trace table, before/after values, rationale for each decision.

Closes #32

## Test plan
- [x] Unit tests pass — 1371 tests, all green
- [x] Typecheck passes (`npm run build`)
- [x] 5 playthroughs completed via `playwright-playthrough.mjs`; final trace 20%, sentinel never activated on optimal path

## Known limitations
- Playthroughs are automated critical-path runs; a human first-playthrough with mistakes accumulates more trace. The 61% threshold / interval=2 tuning is validated analytically (see `docs/balance-notes.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>