### PR TITLE
feat(ui): color theme switcher

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,6 +31,8 @@ import { loadDossier } from './engine/dossierPersistence';
 import { selectContract } from './data/contracts';
 import { DIVISION_LAYER } from './data/divisionSeeds';
 import type { ContractDefinition } from './types/game';
+import { THEMES, THEME_LABELS, applyTheme, saveTheme, loadTheme } from './engine/themes';
+import type { Theme } from './engine/themes';
 
 const computeContextSuggestions = (state: GameState): string[] => {
   const node = state.network.nodes[state.network.currentNodeId];
@@ -164,6 +166,11 @@ export const App = () => {
   const [notesOpen, setNotesOpen] = useState(false);
   const [pendingContract, setPendingContract] = useState<ContractDefinition | null>(null);
   const [contractRerollUsed, setContractRerollUsed] = useState(false);
+  const [currentTheme, setCurrentTheme] = useState<Theme>(() => {
+    const t = loadTheme();
+    applyTheme(t);
+    return t;
+  });
 
   const terminalRef = useRef<TerminalHandle>(null);
   const bootHandled = useRef(false);
@@ -599,6 +606,32 @@ export const App = () => {
         return;
       }
 
+      if (raw.trim().toLowerCase().startsWith('theme')) {
+        const arg = raw.trim().slice(5).trim().toLowerCase();
+        push([makeLine('input', raw)]);
+        if (!arg) {
+          push([
+            makeLine('system', 'Available themes:'),
+            ...THEMES.map(t =>
+              makeLine('system', `  ${t === currentTheme ? '>' : ' '} ${THEME_LABELS[t]}`),
+            ),
+            makeLine('system', 'Usage: theme <name>'),
+          ]);
+        } else if ((THEMES as readonly string[]).includes(arg)) {
+          const next = arg as Theme;
+          applyTheme(next);
+          saveTheme(next);
+          setCurrentTheme(next);
+          push([makeLine('system', `// Terminal theme set to: ${next}`)]);
+        } else {
+          push([
+            makeLine('error', `// Unknown theme: ${arg}`),
+            makeLine('system', `Available: ${THEMES.join(', ')}`),
+          ]);
+        }
+        return;
+      }
+
       push([makeLine('input', raw)]);
       startSpinner();
 
@@ -744,6 +777,7 @@ export const App = () => {
     [
       appPhase,
       contractRerollUsed,
+      currentTheme,
       gameState,
       pendingContract,
       push,

--- a/src/components/HelpModal.tsx
+++ b/src/components/HelpModal.tsx
@@ -28,6 +28,7 @@ const BODY: HelpLine[] = [
   { text: r('  status        -session overview'), color: 'var(--color-system)' },
   { text: r('  map           -discovered network nodes'), color: 'var(--color-system)' },
   { text: r('  clear         -clear terminal'), color: 'var(--color-system)' },
+  { text: r('  theme [name]  -list or switch color themes'), color: 'var(--color-system)' },
   { text: r(), color: 'var(--color-system)' },
   { text: r('ENGINE COMMANDS:'), color: 'var(--color-output)' },
   {

--- a/src/engine/themes.ts
+++ b/src/engine/themes.ts
@@ -14,7 +14,9 @@ const isTheme = (value: string): value is Theme => (THEMES as readonly string[])
 
 export const applyTheme = (theme: Theme): void => {
   const root = document.documentElement;
-  THEMES.forEach(t => { root.classList.remove(`theme-${t}`); });
+  THEMES.forEach(t => {
+    root.classList.remove(`theme-${t}`);
+  });
   if (theme !== 'classic') {
     root.classList.add(`theme-${theme}`);
   }

--- a/src/engine/themes.ts
+++ b/src/engine/themes.ts
@@ -1,0 +1,30 @@
+const THEME_KEY = 'irongate_theme';
+
+export const THEMES = ['classic', 'green', 'amber', 'slate'] as const;
+export type Theme = (typeof THEMES)[number];
+
+export const THEME_LABELS: Record<Theme, string> = {
+  classic: 'Classic  (ncurses blue/yellow)',
+  green: 'Green    (phosphor CRT)',
+  amber: 'Amber    (warm phosphor)',
+  slate: 'Slate    (dark modern)',
+};
+
+const isTheme = (value: string): value is Theme => (THEMES as readonly string[]).includes(value);
+
+export const applyTheme = (theme: Theme): void => {
+  const root = document.documentElement;
+  THEMES.forEach(t => { root.classList.remove(`theme-${t}`); });
+  if (theme !== 'classic') {
+    root.classList.add(`theme-${theme}`);
+  }
+};
+
+export const saveTheme = (theme: Theme): void => {
+  localStorage.setItem(THEME_KEY, theme);
+};
+
+export const loadTheme = (): Theme => {
+  const stored = localStorage.getItem(THEME_KEY);
+  return stored && isTheme(stored) ? stored : 'classic';
+};

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -95,6 +95,61 @@ body {
   font-style: italic;
 }
 
+/* ── Color themes ─────────────────────────────────────────── */
+:root.theme-green {
+  --color-bg: #0a1a0a;
+  --color-bg-header: #0a1a0a;
+  --color-border: #33aa33;
+  --color-output: #aaffaa;
+  --color-input: #aaffaa;
+  --color-system: #55ff55;
+  --color-separator: #33aa33;
+  --color-dim: #557755;
+  --color-error: #ff5555;
+  --color-aria: #55ffff;
+  --color-aria-border: #00aaaa;
+  --color-safe: #55ff55;
+  --color-elevated: #ffff55;
+  --color-active: #ff9900;
+  --color-aggressive: #ff5555;
+}
+
+:root.theme-amber {
+  --color-bg: #120d00;
+  --color-bg-header: #120d00;
+  --color-border: #aa6600;
+  --color-output: #ffcc66;
+  --color-input: #ffcc66;
+  --color-system: #ffaa00;
+  --color-separator: #aa6600;
+  --color-dim: #886633;
+  --color-error: #ff5555;
+  --color-aria: #55ffff;
+  --color-aria-border: #00aaaa;
+  --color-safe: #55ff55;
+  --color-elevated: #ffaa00;
+  --color-active: #ff6600;
+  --color-aggressive: #ff5555;
+}
+
+:root.theme-slate {
+  --color-bg: #0d1117;
+  --color-bg-header: #0d1117;
+  --color-border: #30a0a0;
+  --color-output: #c9d1d9;
+  --color-input: #c9d1d9;
+  --color-system: #58a6ff;
+  --color-separator: #21262d;
+  --color-dim: #6e7681;
+  --color-error: #f85149;
+  --color-aria: #79c0ff;
+  --color-aria-border: #388bfd;
+  --color-safe: #56d364;
+  --color-elevated: #e3b341;
+  --color-active: #f0883e;
+  --color-aggressive: #f85149;
+}
+
 /* ── Sentinel DM mode — full terminal takeover ────────────── */
 body.dm-sentinel {
   --color-bg: #000000;


### PR DESCRIPTION
## Summary

- Adds `theme` terminal command to list and switch between 4 color schemes
- **classic** — original ncurses blue/yellow
- **green** — phosphor CRT green
- **amber** — warm phosphor (recommended for long sessions)
- **slate** — dark modern

Theme preference persists across sessions via `localStorage` (key: `irongate_theme`), separate from game save state.

## Test plan

- [ ] `theme` lists all 4 themes with `>` marking the current one
- [ ] `theme amber` / `theme green` / `theme slate` / `theme classic` switches immediately
- [ ] Preference survives a page reload
- [ ] `theme bogus` shows an error with the valid names
- [ ] Sentinel DM mode override still works on top of any theme
- [ ] Build passes (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)