### PR TITLE
feat(engine): Aria mutation — nudge_trust

### DIFF
--- a/src/engine/__tests__/ariaMutations.test.ts
+++ b/src/engine/__tests__/ariaMutations.test.ts
@@ -601,6 +601,218 @@ describe('runAriaTurn — mutation priority', () => {
   });
 });
 
+// ── nudge_trust mutation ───────────────────────────────────
+
+describe('runAriaTurn — nudge_trust', () => {
+  it('decreases trustScore by 4 when player trace >= 61', () => {
+    const state = makeAriaState({
+      aria: { discovered: true, trustScore: 50, messageHistory: [], suppressedMutations: 0 },
+      player: {
+        handle: 'ghost',
+        trace: 70,
+        charges: 3,
+        credentials: [],
+        exfiltrated: [],
+        tools: [],
+        burnCount: 0,
+      },
+    });
+
+    const result = runAriaTurn(state);
+    expect(result.state.aria.trustScore).toBe(46);
+  });
+
+  it('logs a nudge_trust MutationEvent with agent aria and visibleToPlayer false on high trace', () => {
+    const state = makeAriaState({
+      aria: { discovered: true, trustScore: 50, messageHistory: [], suppressedMutations: 0 },
+      player: {
+        handle: 'ghost',
+        trace: 65,
+        charges: 3,
+        credentials: [],
+        exfiltrated: [],
+        tools: [],
+        burnCount: 0,
+      },
+    });
+
+    const result = runAriaTurn(state);
+
+    const events = result.state.sentinel.mutationLog;
+    expect(events).toHaveLength(1);
+    const event = events[0];
+    expect(event.action).toBe('nudge_trust');
+    expect(event.agent).toBe('aria');
+    expect(event.visibleToPlayer).toBe(false);
+    expect(typeof event.reason).toBe('string');
+    expect(event.reason!.length).toBeGreaterThan(0);
+  });
+
+  it('decreases trustScore by 3 when turnCount > 0 and no message history', () => {
+    const state = makeAriaState({
+      turnCount: 5,
+      aria: { discovered: true, trustScore: 50, messageHistory: [], suppressedMutations: 0 },
+      player: {
+        handle: 'ghost',
+        trace: 0,
+        charges: 3,
+        credentials: [],
+        exfiltrated: [],
+        tools: [],
+        burnCount: 0,
+      },
+    });
+
+    const result = runAriaTurn(state);
+    expect(result.state.aria.trustScore).toBe(47);
+
+    const event = result.state.sentinel.mutationLog[0];
+    expect(event.action).toBe('nudge_trust');
+  });
+
+  it('increases trustScore by 3 when messageHistory.length >= 3', () => {
+    const state = makeAriaState({
+      turnCount: 5,
+      aria: {
+        discovered: true,
+        trustScore: 50,
+        messageHistory: [
+          { role: 'player', content: 'hello' },
+          { role: 'aria', content: 'hi' },
+          { role: 'player', content: 'thanks' },
+        ],
+        suppressedMutations: 0,
+      },
+      player: {
+        handle: 'ghost',
+        trace: 0,
+        charges: 3,
+        credentials: [],
+        exfiltrated: [],
+        tools: [],
+        burnCount: 0,
+      },
+    });
+
+    const result = runAriaTurn(state);
+    expect(result.state.aria.trustScore).toBe(53);
+
+    const event = result.state.sentinel.mutationLog[0];
+    expect(event.action).toBe('nudge_trust');
+  });
+
+  it('clamps trustScore to 0 when high trace would push below 0', () => {
+    const state = makeAriaState({
+      aria: { discovered: true, trustScore: 2, messageHistory: [], suppressedMutations: 0 },
+      player: {
+        handle: 'ghost',
+        trace: 70,
+        charges: 3,
+        credentials: [],
+        exfiltrated: [],
+        tools: [],
+        burnCount: 0,
+      },
+    });
+
+    const result = runAriaTurn(state);
+    expect(result.state.aria.trustScore).toBe(0);
+  });
+
+  it('clamps trustScore to 100 when engagement would push above 100', () => {
+    const state = makeAriaState({
+      turnCount: 5,
+      aria: {
+        discovered: true,
+        trustScore: 98,
+        messageHistory: [
+          { role: 'player', content: 'hello' },
+          { role: 'aria', content: 'hi' },
+          { role: 'player', content: 'thanks' },
+        ],
+        suppressedMutations: 0,
+      },
+      player: {
+        handle: 'ghost',
+        trace: 0,
+        charges: 3,
+        credentials: [],
+        exfiltrated: [],
+        tools: [],
+        burnCount: 0,
+      },
+    });
+
+    const result = runAriaTurn(state);
+    expect(result.state.aria.trustScore).toBe(100);
+  });
+
+  it('returns state unchanged when no trigger conditions are met', () => {
+    // turnCount = 0, trace < 61, messageHistory.length < 3 → no match
+    const state = makeAriaState({
+      turnCount: 0,
+      aria: {
+        discovered: true,
+        trustScore: 50,
+        messageHistory: [{ role: 'player', content: 'hello' }],
+        suppressedMutations: 0,
+      },
+      player: {
+        handle: 'ghost',
+        trace: 30,
+        charges: 3,
+        credentials: [],
+        exfiltrated: [],
+        tools: [],
+        burnCount: 0,
+      },
+    });
+
+    const result = runAriaTurn(state);
+    expect(result.state).toBe(state);
+    expect(result.state.sentinel.mutationLog).toHaveLength(0);
+  });
+
+  it('high-trace condition takes priority over quiet-period when both are true', () => {
+    // trace >= 61 AND turnCount > 0 AND messageHistory empty → high-trace fires (-4 not -3)
+    const state = makeAriaState({
+      turnCount: 5,
+      aria: { discovered: true, trustScore: 50, messageHistory: [], suppressedMutations: 0 },
+      player: {
+        handle: 'ghost',
+        trace: 65,
+        charges: 3,
+        credentials: [],
+        exfiltrated: [],
+        tools: [],
+        burnCount: 0,
+      },
+    });
+
+    const result = runAriaTurn(state);
+    expect(result.state.aria.trustScore).toBe(46); // -4, not -3
+  });
+
+  it('produces no visible terminal lines (silent mutation)', () => {
+    const state = makeAriaState({
+      turnCount: 5,
+      aria: { discovered: true, trustScore: 50, messageHistory: [], suppressedMutations: 0 },
+      player: {
+        handle: 'ghost',
+        trace: 0,
+        charges: 3,
+        credentials: [],
+        exfiltrated: [],
+        tools: [],
+        burnCount: 0,
+      },
+    });
+
+    const result = runAriaTurn(state);
+    expect(result.lines).toHaveLength(0);
+  });
+});
+
 // ── MutationEvent.reason field ─────────────────────────────
 
 describe('runAriaTurn — MutationEvent.reason populated', () => {

--- a/src/engine/ariaMutations.ts
+++ b/src/engine/ariaMutations.ts
@@ -123,6 +123,10 @@ const tryNudgeTrust = (state: GameState): { state: GameState; lines: AriaLine[] 
   }
 
   const newTrust = Math.min(100, Math.max(0, state.aria.trustScore + delta));
+
+  // No-op if already at the clamp boundary — skip to avoid a misleading post-game event.
+  if (newTrust === state.aria.trustScore) return null;
+
   const event = makeMutationEvent('nudge_trust', state.turnCount, { reason });
 
   const next = produce(state, s => {
@@ -130,6 +134,7 @@ const tryNudgeTrust = (state: GameState): { state: GameState; lines: AriaLine[] 
     s.sentinel.mutationLog.push(event);
   });
 
+  // §9.5 guard omitted: trust-score changes do not affect graph reachability.
   return { state: next, lines: [] };
 };
 

--- a/src/engine/ariaMutations.ts
+++ b/src/engine/ariaMutations.ts
@@ -103,6 +103,36 @@ const tryRerouteEdge = (state: GameState): { state: GameState; lines: AriaLine[]
   return { state: next, lines: [] };
 };
 
+// ── Any trust level: silently nudge trustScore based on game conditions ──
+
+const tryNudgeTrust = (state: GameState): { state: GameState; lines: AriaLine[] } | null => {
+  let delta: number;
+  let reason: string;
+
+  if (state.player.trace >= 61) {
+    delta = -4;
+    reason = 'Player trace elevated — Aria recalibrates trust';
+  } else if (state.turnCount > 0 && state.aria.messageHistory.length === 0) {
+    delta = -3;
+    reason = 'No contact from player — Aria adjusts trust baseline';
+  } else if (state.aria.messageHistory.length >= 3) {
+    delta = 3;
+    reason = 'Sustained contact — Aria trust reinforced';
+  } else {
+    return null;
+  }
+
+  const newTrust = Math.min(100, Math.max(0, state.aria.trustScore + delta));
+  const event = makeMutationEvent('nudge_trust', state.turnCount, { reason });
+
+  const next = produce(state, s => {
+    s.aria.trustScore = newTrust;
+    s.sentinel.mutationLog.push(event);
+  });
+
+  return { state: next, lines: [] };
+};
+
 // ── Main entry point ──────────────────────────────────────────────────────
 
 export const runAriaTurn = (state: GameState): { state: GameState; lines: AriaLine[] } => {
@@ -124,6 +154,10 @@ export const runAriaTurn = (state: GameState): { state: GameState; lines: AriaLi
     const result = tryRerouteEdge(state);
     if (result) return result;
   }
+
+  // Any trust level: nudge trustScore based on game conditions.
+  const nudge = tryNudgeTrust(state);
+  if (nudge) return nudge;
 
   return { state, lines: [] };
 };


### PR DESCRIPTION
## Summary

- Adds `tryNudgeTrust` to `src/engine/ariaMutations.ts`: a self-referential Aria mutation that silently adjusts `aria.trustScore` based on game conditions
- Wires `tryNudgeTrust` as the fallback at the end of `runAriaTurn` (fires when no higher-priority mutation applies)
- Three ordered trigger conditions: high trace (≥61) → −4, quiet period (turnCount > 0 & no messages) → −3, sustained engagement (≥3 messages) → +3; score clamped to [0, 100]
- Adds 8 tests covering all conditions, clamping, priority, and silent-mutation behaviour

## Test plan

- [x] High-trace condition: trustScore decreases by 4, MutationEvent logged correctly
- [x] Quiet-period condition: trustScore decreases by 3 when no message history
- [x] Engagement condition: trustScore increases by 3 when messageHistory.length ≥ 3
- [x] Clamping at 0: start at trustScore 2 with high trace → result is 0
- [x] Clamping at 100: start at trustScore 98 with engagement → result is 100
- [x] No trigger conditions met: state unchanged, no event logged
- [x] High-trace takes priority over quiet-period
- [x] Silent mutation: lines array is empty
- [x] `npm test` — 1391 tests, all pass
- [x] `npm run lint` — no errors
- [x] `npm run build` — clean build

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)