### PR TITLE
feat(engine): Aria mutation — plant_file

### DIFF
--- a/src/engine/__tests__/ariaMutations.test.ts
+++ b/src/engine/__tests__/ariaMutations.test.ts
@@ -251,7 +251,10 @@ describe('runAriaTurn — trust 60 reroute_edge', () => {
     });
 
     const result = runAriaTurn(state);
-    expect(result.state.sentinel.mutationLog).toHaveLength(0);
+    // reroute_edge must not fire — plant_file (trust 40) may still fire
+    expect(result.state.sentinel.mutationLog.filter(e => e.action === 'reroute_edge')).toHaveLength(
+      0,
+    );
   });
 
   it('produces no visible terminal lines (silent mutation)', () => {
@@ -678,7 +681,7 @@ describe('runAriaTurn — trust 50 modify_file', () => {
     expect(event.filePath).toBe('/etc/info.txt');
   });
 
-  it('returns state unchanged when no eligible files exist (all null content)', () => {
+  it('does not fire modify_file when no eligible files exist (all null content)', () => {
     const nodeWithNullContent = makeNode({
       id: 'node_b',
       ip: '10.1.2.1',
@@ -708,11 +711,13 @@ describe('runAriaTurn — trust 50 modify_file', () => {
     });
 
     const result = runAriaTurn(state);
-    expect(result.state).toBe(state);
-    expect(result.state.sentinel.mutationLog).toHaveLength(0);
+    // modify_file must not fire — plant_file may still fire as fallback
+    expect(result.state.sentinel.mutationLog.filter(e => e.action === 'modify_file')).toHaveLength(
+      0,
+    );
   });
 
-  it('skips files already in ariaInfluencedFilesRead', () => {
+  it('does not fire modify_file for files already in ariaInfluencedFilesRead', () => {
     const fileNode = makeFileNode('node_c', 1);
     const state = makeAriaState({
       network: {
@@ -728,8 +733,10 @@ describe('runAriaTurn — trust 50 modify_file', () => {
     });
 
     const result = runAriaTurn(state);
-    expect(result.state).toBe(state);
-    expect(result.state.sentinel.mutationLog).toHaveLength(0);
+    // modify_file must not fire — plant_file may still fire as fallback
+    expect(result.state.sentinel.mutationLog.filter(e => e.action === 'modify_file')).toHaveLength(
+      0,
+    );
   });
 
   it('rolls back modify_file if it would make the game unwinnable (§9.5)', async () => {
@@ -867,6 +874,154 @@ describe('runAriaTurn — trust 50 modify_file', () => {
     const result = runAriaTurn(state);
     expect(result.state).toBe(state);
     expect(result.state.sentinel.mutationLog).toHaveLength(0);
+  });
+});
+
+// ── Trust 40: plant_file ──────────────────────────────────
+
+describe('runAriaTurn — trust 40 plant_file', () => {
+  it('plants a file on the first eligible discovered non-aria node (sorted by id)', () => {
+    const current = makeNode({ id: 'current', ip: '10.5.0.1', layer: 5, connections: [] });
+    const nodeA = makeNode({ id: 'node_a', ip: '10.0.0.2', layer: 0, discovered: true });
+    const nodeB = makeNode({ id: 'node_b', ip: '10.0.0.3', layer: 1, discovered: true });
+    const state = makeState({
+      turnCount: 7,
+      network: {
+        currentNodeId: 'current',
+        previousNodeId: null,
+        nodes: { current, node_a: nodeA, node_b: nodeB },
+      },
+      aria: { discovered: true, trustScore: 40, messageHistory: [], suppressedMutations: 0 },
+    });
+
+    const result = runAriaTurn(state);
+
+    // node_a sorts first alphabetically and should receive the file
+    const files = result.state.network.nodes['node_a']?.files ?? [];
+    expect(files).toHaveLength(1);
+    expect(files[0].path).toBe('/tmp/.aria_hint_7.txt');
+    expect(files[0].content).toBeTruthy();
+  });
+
+  it('logs a plant_file MutationEvent with correct fields', () => {
+    const current = makeNode({ id: 'current', ip: '10.5.0.1', layer: 5, connections: [] });
+    const nodeA = makeNode({ id: 'node_a', ip: '10.0.0.2', layer: 0, discovered: true });
+    const state = makeState({
+      turnCount: 3,
+      network: {
+        currentNodeId: 'current',
+        previousNodeId: null,
+        nodes: { current, node_a: nodeA },
+      },
+      aria: { discovered: true, trustScore: 45, messageHistory: [], suppressedMutations: 0 },
+    });
+
+    const result = runAriaTurn(state);
+
+    const events = result.state.sentinel.mutationLog;
+    expect(events).toHaveLength(1);
+    const event = events[0];
+    expect(event.agent).toBe('aria');
+    expect(event.action).toBe('plant_file');
+    expect(event.visibleToPlayer).toBe(false);
+    expect(event.nodeId).toBe('node_a');
+    expect(event.filePath).toBe('/tmp/.aria_hint_3.txt');
+    expect(typeof event.reason).toBe('string');
+    expect(event.reason!.length).toBeGreaterThan(0);
+  });
+
+  it('planted file has ariaPlanted: true and planted: true', () => {
+    const current = makeNode({ id: 'current', ip: '10.5.0.1', layer: 5, connections: [] });
+    const nodeA = makeNode({ id: 'node_a', ip: '10.0.0.2', layer: 0, discovered: true });
+    const state = makeState({
+      network: {
+        currentNodeId: 'current',
+        previousNodeId: null,
+        nodes: { current, node_a: nodeA },
+      },
+      aria: { discovered: true, trustScore: 40, messageHistory: [], suppressedMutations: 0 },
+    });
+
+    const result = runAriaTurn(state);
+
+    const file = result.state.network.nodes['node_a']?.files[0];
+    expect(file?.ariaPlanted).toBe(true);
+    expect(file?.planted).toBe(true);
+  });
+
+  it('returns state unchanged (no mutation) when all nodes are layer 5 or no other nodes exist', () => {
+    const current = makeNode({ id: 'current', ip: '10.5.0.1', layer: 5, connections: [] });
+    const ariaNode = makeNode({ id: 'aria_node', ip: '10.5.0.2', layer: 5, discovered: true });
+    const state = makeState({
+      network: {
+        currentNodeId: 'current',
+        previousNodeId: null,
+        nodes: { current, aria_node: ariaNode },
+      },
+      aria: { discovered: true, trustScore: 40, messageHistory: [], suppressedMutations: 0 },
+    });
+
+    const result = runAriaTurn(state);
+    expect(result.state.sentinel.mutationLog).toHaveLength(0);
+    expect(result.state).toBe(state);
+  });
+
+  it('returns state unchanged when current node is the only non-aria node', () => {
+    const current = makeNode({ id: 'current', ip: '10.0.0.1', layer: 0, discovered: true });
+    const state = makeState({
+      network: {
+        currentNodeId: 'current',
+        previousNodeId: null,
+        nodes: { current },
+      },
+      aria: { discovered: true, trustScore: 40, messageHistory: [], suppressedMutations: 0 },
+    });
+
+    const result = runAriaTurn(state);
+    expect(result.state.sentinel.mutationLog).toHaveLength(0);
+    expect(result.state).toBe(state);
+  });
+
+  it('rolls back plant_file if it would make the game unwinnable (§9.5)', async () => {
+    const guardModule = await import('../completabilityGuard');
+    const spy = vi.spyOn(guardModule, 'isGameCompletable').mockReturnValue(false);
+
+    const current = makeNode({ id: 'current', ip: '10.5.0.1', layer: 5, connections: [] });
+    const nodeA = makeNode({ id: 'node_a', ip: '10.0.0.2', layer: 0, discovered: true });
+    const state = makeState({
+      network: {
+        currentNodeId: 'current',
+        previousNodeId: null,
+        nodes: { current, node_a: nodeA },
+      },
+      aria: { discovered: true, trustScore: 40, messageHistory: [], suppressedMutations: 0 },
+    });
+
+    const result = runAriaTurn(state);
+
+    // No file planted — mutation rolled back
+    expect(result.state.network.nodes['node_a']?.files).toHaveLength(0);
+    expect(result.state.sentinel.mutationLog.filter(e => e.action === 'plant_file')).toHaveLength(
+      0,
+    );
+
+    spy.mockRestore();
+  });
+
+  it('produces no visible terminal lines (silent mutation)', () => {
+    const current = makeNode({ id: 'current', ip: '10.5.0.1', layer: 5, connections: [] });
+    const nodeA = makeNode({ id: 'node_a', ip: '10.0.0.2', layer: 0, discovered: true });
+    const state = makeState({
+      network: {
+        currentNodeId: 'current',
+        previousNodeId: null,
+        nodes: { current, node_a: nodeA },
+      },
+      aria: { discovered: true, trustScore: 40, messageHistory: [], suppressedMutations: 0 },
+    });
+
+    const result = runAriaTurn(state);
+    expect(result.lines).toHaveLength(0);
   });
 });
 

--- a/src/engine/ariaMutations.ts
+++ b/src/engine/ariaMutations.ts
@@ -188,7 +188,7 @@ const tryPlantFile = (state: GameState): { state: GameState; lines: AriaLine[] }
   if (candidates.length === 0) return null;
 
   const target = candidates[0];
-  const filePath = `/tmp/.aria_hint_${String(state.turnCount)}.txt`;
+  const filePath = `/tmp/.aria_hint_${state.turnCount}.txt`;
   const hintContent = '// Cross-reference the exfil manifest with layer 2 credentials.';
 
   const event = makeMutationEvent('plant_file', state.turnCount, {
@@ -201,7 +201,7 @@ const tryPlantFile = (state: GameState): { state: GameState; lines: AriaLine[] }
     const node = s.network.nodes[target.id];
     if (node) {
       node.files.push({
-        name: `.aria_hint_${String(state.turnCount)}.txt`,
+        name: `.aria_hint_${state.turnCount}.txt`,
         path: filePath,
         type: 'document',
         content: hintContent,

--- a/src/engine/ariaMutations.ts
+++ b/src/engine/ariaMutations.ts
@@ -188,7 +188,7 @@ const tryPlantFile = (state: GameState): { state: GameState; lines: AriaLine[] }
   if (candidates.length === 0) return null;
 
   const target = candidates[0];
-  const filePath = `/tmp/.aria_hint_${state.turnCount}.txt`;
+  const filePath = `/tmp/.aria_hint_${String(state.turnCount)}.txt`;
   const hintContent = '// Cross-reference the exfil manifest with layer 2 credentials.';
 
   const event = makeMutationEvent('plant_file', state.turnCount, {
@@ -201,7 +201,7 @@ const tryPlantFile = (state: GameState): { state: GameState; lines: AriaLine[] }
     const node = s.network.nodes[target.id];
     if (node) {
       node.files.push({
-        name: `.aria_hint_${state.turnCount}.txt`,
+        name: `.aria_hint_${String(state.turnCount)}.txt`,
         path: filePath,
         type: 'document',
         content: hintContent,

--- a/src/engine/ariaMutations.ts
+++ b/src/engine/ariaMutations.ts
@@ -167,6 +167,60 @@ const tryModifyFile = (state: GameState): { state: GameState; lines: AriaLine[] 
   return { state: next, lines: [] };
 };
 
+// ── Trust 40: plant a hint file on a discovered non-aria node ────────────
+
+const tryPlantFile = (state: GameState): { state: GameState; lines: AriaLine[] } | null => {
+  // Candidate nodes: discovered, layer !== 5 (non-aria), not the current node,
+  // and not already seeded with an aria-planted file (one hint per node).
+  // network.nodes contains the full map; discovered is the actual eligibility gate.
+  // Sort by id for determinism.
+  const candidates = Object.values(state.network.nodes)
+    .filter(
+      (n): n is LiveNode =>
+        !!n &&
+        n.discovered &&
+        n.layer !== 5 &&
+        n.id !== state.network.currentNodeId &&
+        !n.files.some(f => f.ariaPlanted),
+    )
+    .sort((a, b) => a.id.localeCompare(b.id));
+
+  if (candidates.length === 0) return null;
+
+  const target = candidates[0];
+  const filePath = `/tmp/.aria_hint_${String(state.turnCount)}.txt`;
+  const hintContent = '// Cross-reference the exfil manifest with layer 2 credentials.';
+
+  const event = makeMutationEvent('plant_file', state.turnCount, {
+    nodeId: target.id,
+    filePath,
+    reason: 'Planting hint file to guide player toward key credentials',
+  });
+
+  const next = produce(state, s => {
+    const node = s.network.nodes[target.id];
+    if (node) {
+      node.files.push({
+        name: `.aria_hint_${String(state.turnCount)}.txt`,
+        path: filePath,
+        type: 'document',
+        content: hintContent,
+        exfiltrable: false,
+        accessRequired: 'user',
+        planted: true,
+        ariaPlanted: true,
+      });
+    }
+    s.sentinel.mutationLog.push(event);
+  });
+
+  // §9.5: adding a file cannot affect BFS reachability — structurally unreachable,
+  // but kept for consistency with the sentinel pattern.
+  if (!isGameCompletable(next)) return null;
+
+  return { state: next, lines: [] };
+};
+
 // ── Any trust level: silently nudge trustScore based on game conditions ──
 
 const tryNudgeTrust = (state: GameState): { state: GameState; lines: AriaLine[] } | null => {
@@ -225,9 +279,16 @@ export const runAriaTurn = (state: GameState): { state: GameState; lines: AriaLi
   }
 
   // Trust 50: silently modify an unread file with an intelligence update.
-  // Once all eligible files have been modified, falls through to nudge_trust below.
+  // Once all eligible files have been modified, falls through to plant_file below.
   if (trustScore >= 50) {
     const result = tryModifyFile(state);
+    if (result) return result;
+  }
+
+  // Trust 40: plant a hint file on an eligible discovered node.
+  // Once all eligible nodes are seeded, falls through to nudge_trust below.
+  if (trustScore >= 40) {
+    const result = tryPlantFile(state);
     if (result) return result;
   }
 


### PR DESCRIPTION
## Summary

- Adds `tryPlantFile` as the Trust 40 tier of Aria's silent background mutations in `src/engine/ariaMutations.ts`
- Plants a cryptic hint file (`/tmp/.aria_hint_<turnCount>.txt`) on the first eligible discovered non-aria node (layer !== 5, not current node, sorted by id for determinism)
- Logs a `MutationEvent` with `action: 'plant_file'`, `nodeId`, `filePath`, and `reason`; `visibleToPlayer: false` (silent mutation)
- Applies §9.5 completability rollback guard — mutation is silently discarded if it would make the game unwinnable
- Wired into `runAriaTurn` as the lowest-priority tier (fires only when trust-80 and trust-60 mutations are ineligible)

## Test plan

- [x] Happy path: file planted on first eligible node, `MutationEvent` logged with correct `agent`, `action`, `nodeId`, `filePath`, `reason`
- [x] Planted file has `ariaPlanted: true` and `planted: true`
- [x] No eligible node (all nodes are layer 5 or only current node exists): state unchanged, no event logged
- [x] §9.5 rollback: `isGameCompletable` mocked to return false → no file planted, no event logged
- [x] Silent mutation: `lines` is empty
- [x] All 1389 existing tests pass; build and lint clean

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)