### PR TITLE
feat(engine): Aria mutation — modify_file

### DIFF
--- a/src/engine/__tests__/ariaMutations.test.ts
+++ b/src/engine/__tests__/ariaMutations.test.ts
@@ -601,6 +601,275 @@ describe('runAriaTurn — mutation priority', () => {
   });
 });
 
+// ── Trust 50: modify_file ─────────────────────────────────
+
+describe('runAriaTurn — trust 50 modify_file', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const makeFileNode = (id: string, layer = 1): LiveNode =>
+    makeNode({
+      id,
+      ip: `10.${String(layer)}.1.1`,
+      layer,
+      anchor: false,
+      discovered: true,
+      files: [
+        {
+          name: 'info.txt',
+          path: '/etc/info.txt',
+          type: 'document',
+          content: 'original content',
+          exfiltrable: false,
+          accessRequired: 'user',
+          ariaPlanted: false,
+        },
+      ],
+    });
+
+  it('happy path: updates file content and sets ariaPlanted: true', () => {
+    const fileNode = makeFileNode('node_a', 1);
+    const state = makeAriaState({
+      network: {
+        currentNodeId: 'current',
+        previousNodeId: null,
+        nodes: {
+          current: makeNode({ id: 'current', ip: '10.5.0.1', layer: 5, connections: [] }),
+          node_a: fileNode,
+        },
+      },
+      aria: { discovered: true, trustScore: 50, messageHistory: [], suppressedMutations: 0 },
+    });
+
+    const result = runAriaTurn(state);
+
+    const updatedFile = result.state.network.nodes['node_a']?.files.find(
+      f => f.path === '/etc/info.txt',
+    );
+    expect(updatedFile).toBeDefined();
+    expect(updatedFile?.content).toContain('[ARIA]');
+    expect(updatedFile?.ariaPlanted).toBe(true);
+  });
+
+  it('happy path: logs a modify_file MutationEvent with correct fields', () => {
+    const fileNode = makeFileNode('node_a', 1);
+    const state = makeAriaState({
+      network: {
+        currentNodeId: 'current',
+        previousNodeId: null,
+        nodes: {
+          current: makeNode({ id: 'current', ip: '10.5.0.1', layer: 5, connections: [] }),
+          node_a: fileNode,
+        },
+      },
+      aria: { discovered: true, trustScore: 50, messageHistory: [], suppressedMutations: 0 },
+    });
+
+    const result = runAriaTurn(state);
+
+    const events = result.state.sentinel.mutationLog;
+    expect(events).toHaveLength(1);
+    const event = events[0];
+    expect(event.agent).toBe('aria');
+    expect(event.action).toBe('modify_file');
+    expect(event.visibleToPlayer).toBe(false);
+    expect(event.nodeId).toBe('node_a');
+    expect(event.filePath).toBe('/etc/info.txt');
+  });
+
+  it('returns state unchanged when no eligible files exist (all null content)', () => {
+    const nodeWithNullContent = makeNode({
+      id: 'node_b',
+      ip: '10.1.2.1',
+      layer: 1,
+      discovered: true,
+      files: [
+        {
+          name: 'stub.txt',
+          path: '/etc/stub.txt',
+          type: 'document',
+          content: null,
+          exfiltrable: false,
+          accessRequired: 'user',
+        },
+      ],
+    });
+    const state = makeAriaState({
+      network: {
+        currentNodeId: 'current',
+        previousNodeId: null,
+        nodes: {
+          current: makeNode({ id: 'current', ip: '10.5.0.1', layer: 5, connections: [] }),
+          node_b: nodeWithNullContent,
+        },
+      },
+      aria: { discovered: true, trustScore: 50, messageHistory: [], suppressedMutations: 0 },
+    });
+
+    const result = runAriaTurn(state);
+    expect(result.state).toBe(state);
+    expect(result.state.sentinel.mutationLog).toHaveLength(0);
+  });
+
+  it('skips files already in ariaInfluencedFilesRead', () => {
+    const fileNode = makeFileNode('node_c', 1);
+    const state = makeAriaState({
+      network: {
+        currentNodeId: 'current',
+        previousNodeId: null,
+        nodes: {
+          current: makeNode({ id: 'current', ip: '10.5.0.1', layer: 5, connections: [] }),
+          node_c: fileNode,
+        },
+      },
+      aria: { discovered: true, trustScore: 50, messageHistory: [], suppressedMutations: 0 },
+      ariaInfluencedFilesRead: ['/etc/info.txt'],
+    });
+
+    const result = runAriaTurn(state);
+    expect(result.state).toBe(state);
+    expect(result.state.sentinel.mutationLog).toHaveLength(0);
+  });
+
+  it('rolls back modify_file if it would make the game unwinnable (§9.5)', async () => {
+    const guardModule = await import('../completabilityGuard');
+    const spy = vi.spyOn(guardModule, 'isGameCompletable').mockReturnValue(false);
+
+    const fileNode = makeFileNode('node_d', 1);
+    const state = makeAriaState({
+      network: {
+        currentNodeId: 'current',
+        previousNodeId: null,
+        nodes: {
+          current: makeNode({ id: 'current', ip: '10.5.0.1', layer: 5, connections: [] }),
+          node_d: fileNode,
+        },
+      },
+      aria: { discovered: true, trustScore: 50, messageHistory: [], suppressedMutations: 0 },
+    });
+
+    const result = runAriaTurn(state);
+
+    expect(result.state.sentinel.mutationLog.filter(e => e.action === 'modify_file')).toHaveLength(
+      0,
+    );
+    const file = result.state.network.nodes['node_d']?.files.find(f => f.path === '/etc/info.txt');
+    expect(file?.content).toBe('original content');
+
+    spy.mockRestore();
+  });
+
+  it('produces no visible terminal lines (silent mutation)', () => {
+    const fileNode = makeFileNode('node_e', 1);
+    const state = makeAriaState({
+      network: {
+        currentNodeId: 'current',
+        previousNodeId: null,
+        nodes: {
+          current: makeNode({ id: 'current', ip: '10.5.0.1', layer: 5, connections: [] }),
+          node_e: fileNode,
+        },
+      },
+      aria: { discovered: true, trustScore: 50, messageHistory: [], suppressedMutations: 0 },
+    });
+
+    const result = runAriaTurn(state);
+    expect(result.lines).toHaveLength(0);
+  });
+
+  it('excludes layer 5 nodes from candidates', () => {
+    const layer5Node = makeNode({
+      id: 'aria_node',
+      ip: '10.5.1.1',
+      layer: 5,
+      discovered: true,
+      files: [
+        {
+          name: 'secret.txt',
+          path: '/aria/secret.txt',
+          type: 'document',
+          content: 'aria content',
+          exfiltrable: false,
+          accessRequired: 'user',
+        },
+      ],
+    });
+    const state = makeAriaState({
+      network: {
+        currentNodeId: 'current',
+        previousNodeId: null,
+        nodes: {
+          current: makeNode({ id: 'current', ip: '10.5.0.1', layer: 5, connections: [] }),
+          aria_node: layer5Node,
+        },
+      },
+      aria: { discovered: true, trustScore: 50, messageHistory: [], suppressedMutations: 0 },
+    });
+
+    const result = runAriaTurn(state);
+    expect(result.state).toBe(state);
+    expect(result.state.sentinel.mutationLog).toHaveLength(0);
+  });
+
+  it('does not set planted: true on the modified file', () => {
+    const fileNode = makeFileNode('node_f', 1);
+    const state = makeAriaState({
+      network: {
+        currentNodeId: 'current',
+        previousNodeId: null,
+        nodes: {
+          current: makeNode({ id: 'current', ip: '10.5.0.1', layer: 5, connections: [] }),
+          node_f: fileNode,
+        },
+      },
+      aria: { discovered: true, trustScore: 50, messageHistory: [], suppressedMutations: 0 },
+    });
+
+    const result = runAriaTurn(state);
+
+    const updatedFile = result.state.network.nodes['node_f']?.files.find(
+      f => f.path === '/etc/info.txt',
+    );
+    expect(updatedFile?.planted).toBeFalsy();
+  });
+
+  it('skips files already marked ariaPlanted: true', () => {
+    const nodeWithPlantedFile = makeNode({
+      id: 'node_g',
+      ip: '10.1.3.1',
+      layer: 1,
+      discovered: true,
+      files: [
+        {
+          name: 'planted.txt',
+          path: '/etc/planted.txt',
+          type: 'document',
+          content: 'already planted',
+          exfiltrable: false,
+          accessRequired: 'user',
+          ariaPlanted: true,
+        },
+      ],
+    });
+    const state = makeAriaState({
+      network: {
+        currentNodeId: 'current',
+        previousNodeId: null,
+        nodes: {
+          current: makeNode({ id: 'current', ip: '10.5.0.1', layer: 5, connections: [] }),
+          node_g: nodeWithPlantedFile,
+        },
+      },
+      aria: { discovered: true, trustScore: 50, messageHistory: [], suppressedMutations: 0 },
+    });
+
+    const result = runAriaTurn(state);
+    expect(result.state).toBe(state);
+    expect(result.state.sentinel.mutationLog).toHaveLength(0);
+  });
+});
+
 // ── nudge_trust mutation ───────────────────────────────────
 
 describe('runAriaTurn — nudge_trust', () => {

--- a/src/engine/ariaMutations.ts
+++ b/src/engine/ariaMutations.ts
@@ -103,6 +103,70 @@ const tryRerouteEdge = (state: GameState): { state: GameState; lines: AriaLine[]
   return { state: next, lines: [] };
 };
 
+// ── Trust 50: silently edit an unread file on a discovered node ──────────
+
+const tryModifyFile = (state: GameState): { state: GameState; lines: AriaLine[] } | null => {
+  // Collect all discovered nodes excluding layer 5 (aria subnetwork) and the current node.
+  // Excluding the current node mirrors tryPlantFile — mutations on an actively-browsed node
+  // could surface immediately and should remain invisible until the player moves away.
+  const candidateNodes = Object.values(state.network.nodes)
+    .filter(
+      (n): n is LiveNode =>
+        !!n && n.discovered && n.layer !== 5 && n.id !== state.network.currentNodeId,
+    )
+    .sort((a, b) => a.id.localeCompare(b.id));
+
+  // Find the first eligible file across candidate nodes (sorted by node id, then file path)
+  let targetNodeId: string | null = null;
+  let targetFilePath: string | null = null;
+
+  outer: for (const node of candidateNodes) {
+    const sortedFiles = [...node.files].sort((a, b) => a.path.localeCompare(b.path));
+    for (const file of sortedFiles) {
+      if (
+        file.content !== null &&
+        !file.deleted &&
+        !state.ariaInfluencedFilesRead.includes(file.path) &&
+        !file.ariaPlanted
+      ) {
+        targetNodeId = node.id;
+        targetFilePath = file.path;
+        break outer;
+      }
+    }
+  }
+
+  if (targetNodeId === null || targetFilePath === null) return null;
+
+  const resolvedNodeId = targetNodeId;
+  const resolvedFilePath = targetFilePath;
+
+  const event = makeMutationEvent('modify_file', state.turnCount, {
+    nodeId: resolvedNodeId,
+    filePath: resolvedFilePath,
+    reason: 'Embedding intelligence update in unread file to aid player navigation',
+  });
+
+  const next = produce(state, s => {
+    const node = s.network.nodes[resolvedNodeId];
+    if (node) {
+      const file = node.files.find(f => f.path === resolvedFilePath);
+      if (file) {
+        file.content =
+          '// [ARIA] Intelligence updated: Cross-reference with exec layer for access chain.';
+        file.ariaPlanted = true;
+      }
+    }
+    s.sentinel.mutationLog.push(event);
+  });
+
+  // §9.5: modifying file content cannot affect BFS reachability — structurally unreachable,
+  // but kept for consistency with the sentinel pattern.
+  if (!isGameCompletable(next)) return null;
+
+  return { state: next, lines: [] };
+};
+
 // ── Any trust level: silently nudge trustScore based on game conditions ──
 
 const tryNudgeTrust = (state: GameState): { state: GameState; lines: AriaLine[] } | null => {
@@ -157,6 +221,13 @@ export const runAriaTurn = (state: GameState): { state: GameState; lines: AriaLi
   // Trust 60: add a shortcut edge to a higher-layer anchor.
   if (trustScore >= 60) {
     const result = tryRerouteEdge(state);
+    if (result) return result;
+  }
+
+  // Trust 50: silently modify an unread file with an intelligence update.
+  // Once all eligible files have been modified, falls through to nudge_trust below.
+  if (trustScore >= 50) {
+    const result = tryModifyFile(state);
     if (result) return result;
   }
 


### PR DESCRIPTION
## Summary

- Adds `tryModifyFile` mutation to `src/engine/ariaMutations.ts` that fires at trust ≥ 50
- Silently edits the content of the first eligible unread file on a discovered non-layer-5 node, marking it `ariaPlanted: true`
- Eligible files must have non-null content, not be in `ariaInfluencedFilesRead`, and not already be `ariaPlanted`
- Candidate nodes are sorted by id (then file path) for determinism
- Logs a `MutationEvent` with `action: 'modify_file'`, `nodeId`, `filePath`, and `reason`
- Includes §9.5 unwinnable-game rollback guard (consistent with existing mutations)
- Wired into `runAriaTurn` between trust-60 (`reroute_edge`) and trust-40 (`plant_file`)

## Test plan

- [x] Happy path: file content updated with `[ARIA]` marker, `ariaPlanted: true` set
- [x] Happy path: `MutationEvent` logged with correct `action`, `agent`, `nodeId`, `filePath`, `visibleToPlayer: false`
- [x] No eligible files (all null content): state unchanged, no event logged
- [x] Already-read file (`ariaInfluencedFilesRead`): skipped
- [x] Already `ariaPlanted: true` file: skipped
- [x] §9.5 rollback: `isGameCompletable` mocked to false — no mutation applied
- [x] Silent mutation: `lines` is empty
- [x] Layer 5 nodes excluded from candidates
- [x] `planted` field NOT set (only `ariaPlanted` is set on modify)

Closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)