### PR TITLE
fix(contracts): division-scoped identify_employee via GameFile.sourceNodeId

### DIFF
--- a/src/engine/commands.test.ts
+++ b/src/engine/commands.test.ts
@@ -1635,6 +1635,13 @@ describe('resolveCommand — exfil', () => {
     expect(exfil.some(f => f.name === 'welcome.txt')).toBe(true);
   });
 
+  it('should set sourceNodeId on the exfiltrated file to the current node id', async () => {
+    const result = await resolveCommand('exfil welcome.txt', state);
+    const exfil = (result.nextState as GameState).player.exfiltrated;
+    const file = exfil.find(f => f.name === 'welcome.txt');
+    expect(file?.sourceNodeId).toBe('contractor_portal');
+  });
+
   it('should add 3 trace on successful exfil', async () => {
     const result = await resolveCommand('exfil welcome.txt', state);
     expect((result.nextState as GameState).player.trace).toBe(3);
@@ -3215,8 +3222,8 @@ describe('resolveCommand — contract objective detection', () => {
   // ── identify_employee ─────────────────────────────────────
 
   describe('identify_employee contract', () => {
-    it('should set objectiveComplete = true when employee_roster.csv is exfiltrated', async () => {
-      // employee_roster.csv lives on ops_hr_db; connect there and get user access
+    it('should set objectiveComplete = true when roster is exfiltrated from matching division layer', async () => {
+      // employee_roster.csv lives on ops_hr_db (layer 1 = operations); use divisionId:'operations'
       const state = produce(createInitialState(), s => {
         s.network.currentNodeId = 'ops_hr_db';
         s.network.nodes['ops_hr_db']!.accessLevel = 'user';
@@ -3224,14 +3231,14 @@ describe('resolveCommand — contract objective detection', () => {
           id: 'inside_job',
           networkVariant: 'standard',
           objectiveComplete: false,
-          objectiveCondition: { type: 'identify_employee', divisionId: 'security' },
+          objectiveCondition: { type: 'identify_employee', divisionId: 'operations' },
         };
       });
       const result = await resolveCommand('exfil employee_roster.csv', state);
       expect((result.nextState as GameState).contract?.objectiveComplete).toBe(true);
     });
 
-    it('should append an objective complete system line when employee_roster.csv is exfiltrated', async () => {
+    it('should append an objective complete system line when division layer matches', async () => {
       const state = produce(createInitialState(), s => {
         s.network.currentNodeId = 'ops_hr_db';
         s.network.nodes['ops_hr_db']!.accessLevel = 'user';
@@ -3239,7 +3246,7 @@ describe('resolveCommand — contract objective detection', () => {
           id: 'inside_job',
           networkVariant: 'standard',
           objectiveComplete: false,
-          objectiveCondition: { type: 'identify_employee', divisionId: 'security' },
+          objectiveCondition: { type: 'identify_employee', divisionId: 'operations' },
         };
       });
       const result = await resolveCommand('exfil employee_roster.csv', state);
@@ -3256,12 +3263,52 @@ describe('resolveCommand — contract objective detection', () => {
           id: 'inside_job',
           networkVariant: 'standard',
           objectiveComplete: false,
+          objectiveCondition: { type: 'identify_employee', divisionId: 'operations' },
+        };
+      });
+      const result = await resolveCommand('exfil employee_roster.csv', state);
+      const completeLine = result.lines.find(l => l.content.includes('operations'));
+      expect(completeLine).toBeDefined();
+    });
+
+    it('should NOT set objectiveComplete when roster is from wrong division layer', async () => {
+      // ops_hr_db is layer 1 (operations); security contract requires layer 2
+      const state = produce(createInitialState(), s => {
+        s.network.currentNodeId = 'ops_hr_db';
+        s.network.nodes['ops_hr_db']!.accessLevel = 'user';
+        s.contract = {
+          id: 'inside_job',
+          networkVariant: 'standard',
+          objectiveComplete: false,
           objectiveCondition: { type: 'identify_employee', divisionId: 'security' },
         };
       });
       const result = await resolveCommand('exfil employee_roster.csv', state);
-      const completeLine = result.lines.find(l => l.content.includes('security'));
-      expect(completeLine).toBeDefined();
+      expect((result.nextState as GameState).contract?.objectiveComplete).toBe(false);
+    });
+
+    it('should set objectiveComplete = true when roster is exfiltrated from a layer-2 security node', async () => {
+      // Inject employee_roster.csv onto sec_access_ctrl (layer 2 = security)
+      const state = produce(createInitialState(), s => {
+        s.network.currentNodeId = 'sec_access_ctrl';
+        s.network.nodes['sec_access_ctrl']!.accessLevel = 'user';
+        s.network.nodes['sec_access_ctrl']!.files.push({
+          name: 'employee_roster.csv',
+          path: '/var/db/hr/employee_roster.csv',
+          type: 'document',
+          content: 'sec division personnel',
+          exfiltrable: true,
+          accessRequired: 'user',
+        });
+        s.contract = {
+          id: 'inside_job',
+          networkVariant: 'standard',
+          objectiveComplete: false,
+          objectiveCondition: { type: 'identify_employee', divisionId: 'security' },
+        };
+      });
+      const result = await resolveCommand('exfil employee_roster.csv', state);
+      expect((result.nextState as GameState).contract?.objectiveComplete).toBe(true);
     });
 
     it('should NOT set objectiveComplete when a non-roster file is exfiltrated', async () => {

--- a/src/engine/commands.ts
+++ b/src/engine/commands.ts
@@ -1,6 +1,6 @@
 import type { GameState, CommandOutput, AccessLevel, FavorOffer, ToolId } from '../types/game';
-import type { DivisionId } from '../types/divisionSeed';
 import { hasAccess } from '../types/game';
+import { DIVISION_LAYER } from '../data/divisionSeeds';
 import { currentNode, addTrace, thresholdFlag, TRACE_THRESHOLDS } from './state';
 import produce from './produce';
 import { LAYER_KEY_ANCHOR } from './buildConnectivity';
@@ -338,15 +338,6 @@ const THRESHOLD_ALERT_META: Record<
   },
   61: { msg: '// ALERT: Active intrusion response initiated.', type: 'system' },
   86: { msg: '// CRITICAL: One more detection event triggers full lockout.', type: 'error' },
-};
-
-/** Maps each DivisionId to the network layer it occupies. */
-const DIVISION_LAYER: Record<DivisionId, number> = {
-  external_perimeter: 0,
-  operations: 1,
-  security: 2,
-  finance: 3,
-  executive: 4,
 };
 
 /**

--- a/src/engine/commands.ts
+++ b/src/engine/commands.ts
@@ -1,4 +1,5 @@
 import type { GameState, CommandOutput, AccessLevel, FavorOffer, ToolId } from '../types/game';
+import type { DivisionId } from '../types/divisionSeed';
 import { hasAccess } from '../types/game';
 import { currentNode, addTrace, thresholdFlag, TRACE_THRESHOLDS } from './state';
 import produce from './produce';
@@ -339,15 +340,23 @@ const THRESHOLD_ALERT_META: Record<
   86: { msg: '// CRITICAL: One more detection event triggers full lockout.', type: 'error' },
 };
 
+/** Maps each DivisionId to the network layer it occupies. */
+const DIVISION_LAYER: Record<DivisionId, number> = {
+  external_perimeter: 0,
+  operations: 1,
+  security: 2,
+  finance: 3,
+  executive: 4,
+};
+
 /**
  * Detect contract objective transitions on each turn:
  *   - trace_cap: notify when trace newly crosses the cap (sets a flag so the
  *     message fires exactly once per violation).
  *   - exfil_count: set objectiveComplete = true when the exfil target is reached.
  *   - exfil_file: set objectiveComplete = true when the specific file is exfiltrated.
- *   - identify_employee: set objectiveComplete = true when the employee_roster.csv is
- *     exfiltrated (the roster is the only cross-division employee attribution source).
- *     NOTE: per-division attribution requires tracking source-node on GameFile — deferred.
+ *   - identify_employee: set objectiveComplete = true when employee_roster.csv is
+ *     exfiltrated from a node whose layer matches DIVISION_LAYER[divisionId].
  *   - no_burn: detected in App.tsx at the burn-retry boundary; nothing to do here.
  *   - avoid_division: evaluated at run-end in App.tsx; nothing to do here.
  */
@@ -413,17 +422,19 @@ const applyObjectiveEffects = (prevState: GameState, result: CommandOutput): Com
       });
     }
   } else if (condition.type === 'identify_employee') {
-    // Proxy check: the employee roster is the only file that covers all division personnel.
-    // TODO: filter by condition.divisionId once GameFile.sourceNodeId exists — currently
-    // all identify_employee contracts complete on the same file regardless of target division.
     const EMPLOYEE_ROSTER = 'employee_roster.csv';
-    const prevNames = prevState.player.exfiltrated.map(f => f.name);
-    const nextNames = nextState.player.exfiltrated.map(f => f.name);
-    if (
-      !contract.objectiveComplete &&
-      !prevNames.includes(EMPLOYEE_ROSTER) &&
-      nextNames.includes(EMPLOYEE_ROSTER)
-    ) {
+    const targetLayer = DIVISION_LAYER[condition.divisionId];
+    const prevMatch = prevState.player.exfiltrated.some(
+      f =>
+        f.name === EMPLOYEE_ROSTER &&
+        prevState.network.nodes[f.sourceNodeId ?? '']?.layer === targetLayer,
+    );
+    const nextMatch = nextState.player.exfiltrated.some(
+      f =>
+        f.name === EMPLOYEE_ROSTER &&
+        nextState.network.nodes[f.sourceNodeId ?? '']?.layer === targetLayer,
+    );
+    if (!contract.objectiveComplete && !prevMatch && nextMatch) {
       alertLines.push(
         sep(),
         sys(
@@ -1564,7 +1575,7 @@ const cmdExfil = (args: string[], state: GameState): CommandOutput => {
   const isDecryptorBin = file.path === '/home/ops.admin/sec_tools/decryptor.bin';
 
   let next = produce(addTrace(state, 3, `exfil:${file.name}`), s => {
-    s.player.exfiltrated.push({ ...file });
+    s.player.exfiltrated.push({ ...file, sourceNodeId: node.id });
     // Queue sentinel file-delete for non-Aria nodes.
     // Sentinel processes after turnCount is incremented, so +4 here achieves a true 3-turn delay.
     if (node.layer !== 5) {

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -67,6 +67,7 @@ export interface GameFile {
   planted?: boolean; // dynamically added at runtime (e.g. sentinel RESET_NOTICE); persisted in full
   isTool?: boolean; // file grants a tool when exfil'd; shown with [TOOL] in ls
   toolId?: ToolId; // which tool this file grants
+  sourceNodeId?: string; // node the file was exfiltrated from; set by cmdExfil at runtime
 }
 
 export interface Service {


### PR DESCRIPTION
## Summary

**Engine / Types**
- Add `sourceNodeId?: string` to `GameFile` — set to `node.id` at exfil time in `cmdExfil`
- Add `DIVISION_LAYER` constant mapping `DivisionId → layer number` (external_perimeter=0, operations=1, security=2, finance=3, executive=4)
- `applyObjectiveEffects` `identify_employee` branch now checks that `employee_roster.csv` came from a node at `DIVISION_LAYER[divisionId]`, so `inside_job` (security, layer 2) and `zero_footprint` (finance, layer 3) no longer complete on the `ops_hr_db` roster (layer 1 = operations)
- Removes the `// TODO` comment and deferred-note from the JSDoc

**Tests**
- 3 existing `identify_employee` tests updated: were using `ops_hr_db` (layer 1) with `divisionId: 'security'` — now correctly use `divisionId: 'operations'` to match the layer
- 3 new tests: `sourceNodeId` is set on exfiltrated file; security contract completes when roster is from layer-2 node; security contract does NOT complete when roster is from layer-1 node

Closes #147

## Test plan
- [x] 1410 unit tests pass
- [x] Typecheck passes (`npm run build`)
- [x] Smoke tested: division-scoped matching verified through unit tests; `ops_hr_db` roster correctly blocked for security/finance contracts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>