### PR TITLE
fix(contracts): place c8 ignore directive directly above guarded branch

### DIFF
--- a/src/data/contracts.ts
+++ b/src/data/contracts.ts
@@ -209,8 +209,9 @@ export const selectContract = (excludeId?: string, runsCompleted = 1): ContractD
   const unlocked = CONTRACT_POOL.filter(c => (c.unlockedAfterRun ?? 0) < runsCompleted);
   const base = unlocked.length > 0 ? unlocked : CONTRACT_POOL;
   const eligible = excludeId ? base.filter(c => c.id !== excludeId) : base;
-  // c8 ignore next — eligible is only empty when a single excludeId matches every contract
-  // in base, which cannot happen with a pool of ≥ 2 contracts.
+  // eligible is only empty when a single excludeId matches every contract in base,
+  // which cannot happen with a pool of ≥ 2 contracts.
+  /* c8 ignore next */
   const pool = eligible.length > 0 ? eligible : base;
   return pool[Math.floor(Math.random() * pool.length)];
 };


### PR DESCRIPTION
## Summary

**Engine — contracts.ts**
- The `// c8 ignore next` directive was split across two lines (directive on line 212, explanation on line 213, code on line 214). c8 treated the continuation comment as the "next" line to ignore, so the `eligible.length === 0` ternary branch on line 214 was never suppressed — it remained in the uncovered-branch count.
- Fixed by separating the explanatory comment from the directive and using the `/* c8 ignore next */` block-comment form placed directly above the code line.
- Branch coverage for `contracts.ts`: **77.77% → 85.71%**.

Closes #148

## Test plan
- [x] All 97 existing tests pass (`npx vitest run contracts`)
- [x] Branch coverage for `contracts.ts` ≥ 75% (now 85.71%)
- [x] Typecheck passes (`npm run build`)
- [x] No test descriptions changed — names were already accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>