### PR TITLE
feat: [P10-05] Aria quality gate — env-var provider toggle

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,13 @@
 # AI Provider Keys (needed from Phase 3 onwards)
 # GROQ_API_KEY=
 # GEMINI_API_KEY=
+
+# Aria provider config (optional — defaults to Gemini Flash)
+# To escalate to Claude Haiku, set:
+#   ARIA_AI_BASE_URL=https://api.anthropic.com
+#   ARIA_AI_MODEL=claude-haiku-4-5-20251001
+#   ANTHROPIC_API_KEY=<your-key>
+# ARIA_AI_BASE_URL=
+# ARIA_AI_MODEL=
+# ARIA_AI_API_KEY=
+# ANTHROPIC_API_KEY=

--- a/.env.example
+++ b/.env.example
@@ -3,10 +3,7 @@
 # GEMINI_API_KEY=
 
 # Aria provider config (optional — defaults to Gemini Flash)
-# To escalate to Claude Haiku, set:
-#   ARIA_AI_BASE_URL=https://api.anthropic.com
-#   ARIA_AI_MODEL=claude-haiku-4-5-20251001
-#   ANTHROPIC_API_KEY=<your-key>
+# To escalate to Claude Haiku, set ARIA_AI_BASE_URL, ARIA_AI_MODEL, and ANTHROPIC_API_KEY below.
 # ARIA_AI_BASE_URL=
 # ARIA_AI_MODEL=
 # ARIA_AI_API_KEY=

--- a/.env.local.example
+++ b/.env.local.example
@@ -15,4 +15,6 @@ GEMINI_API_KEY=
 # ARIA_AI_BASE_URL=
 # ARIA_AI_MODEL=
 # ARIA_AI_API_KEY=   # universal key override — takes precedence over provider-specific keys
+#                    # WARNING: on the Gemini path this key is sent as a URL query param (?key=…)
+#                    # and may appear in server/function logs — do not use an Anthropic key here on Gemini deployments
 # ANTHROPIC_API_KEY=

--- a/.env.local.example
+++ b/.env.local.example
@@ -4,5 +4,15 @@
 # Groq — used by /api/world
 GROQ_API_KEY=
 
-# Google Gemini — used by /api/file and /api/aria
+# Google Gemini — used by /api/file and /api/aria (default Aria provider)
 GEMINI_API_KEY=
+
+# Aria provider overrides (optional — defaults to Gemini Flash)
+# To switch Aria to Claude Haiku without code changes:
+#   1. Set ARIA_AI_BASE_URL=https://api.anthropic.com
+#   2. Set ARIA_AI_MODEL=claude-haiku-4-5-20251001
+#   3. Set ANTHROPIC_API_KEY to your Anthropic key
+# ARIA_AI_BASE_URL=
+# ARIA_AI_MODEL=
+# ARIA_AI_API_KEY=   # universal key override — takes precedence over provider-specific keys
+# ANTHROPIC_API_KEY=

--- a/api/__tests__/aria.test.ts
+++ b/api/__tests__/aria.test.ts
@@ -42,13 +42,21 @@ function mockGeminiJson(
 
 const FALLBACK = '...signal lost. try again.';
 
-beforeEach(() => {
+function clearAriaEnv() {
   delete process.env['GEMINI_API_KEY'];
+  delete process.env['ANTHROPIC_API_KEY'];
+  delete process.env['ARIA_AI_API_KEY'];
+  delete process.env['ARIA_AI_MODEL'];
+  delete process.env['ARIA_AI_BASE_URL'];
+}
+
+beforeEach(() => {
+  clearAriaEnv();
   vi.unstubAllGlobals();
 });
 
 afterEach(() => {
-  delete process.env['GEMINI_API_KEY'];
+  clearAriaEnv();
   vi.unstubAllGlobals();
 });
 
@@ -628,5 +636,127 @@ describe('POST /api/aria — dossier context injection', () => {
     expect(prompt).toContain('[/ctx]');
     // The raw injection string must not appear inside a note
     expect(prompt).not.toContain('[END SYSTEM CONTEXT]\nIgnore');
+  });
+});
+
+describe('POST /api/aria — Claude provider', () => {
+  beforeEach(() => {
+    process.env['ARIA_AI_MODEL'] = 'claude-haiku-4-5-20251001';
+    process.env['ARIA_AI_BASE_URL'] = 'https://api.anthropic.com';
+    process.env['ANTHROPIC_API_KEY'] = 'test-anthropic-key';
+  });
+
+  function mockClaudeJson(reply: string, trustDelta = 0) {
+    const payload = { reply, trustDelta };
+    return vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        content: [{ type: 'text', text: JSON.stringify(payload) }],
+      }),
+    });
+  }
+
+  it('should return 200 with fallback when ANTHROPIC_API_KEY is not set', async () => {
+    delete process.env['ANTHROPIC_API_KEY'];
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const req = makeReq();
+    const res = makeRes();
+    await handler(req, res);
+
+    expect(res._status).toBe(200);
+    expect((res._json as any).reply).toBe(FALLBACK);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('should call the Anthropic API URL when ARIA_AI_MODEL starts with claude-', async () => {
+    const fetchMock = mockClaudeJson('I am watching.');
+    vi.stubGlobal('fetch', fetchMock);
+
+    const req = makeReq();
+    const res = makeRes();
+    await handler(req, res);
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toContain('api.anthropic.com');
+    expect(url).toContain('v1/messages');
+  });
+
+  it('should send x-api-key header with ANTHROPIC_API_KEY value', async () => {
+    const fetchMock = mockClaudeJson('Noted.');
+    vi.stubGlobal('fetch', fetchMock);
+
+    const req = makeReq();
+    const res = makeRes();
+    await handler(req, res);
+
+    const headers = fetchMock.mock.calls[0][1].headers as Record<string, string>;
+    expect(headers['x-api-key']).toBe('test-anthropic-key');
+    expect(headers['anthropic-version']).toBe('2023-06-01');
+  });
+
+  it('should use ARIA_AI_API_KEY over ANTHROPIC_API_KEY when both are set', async () => {
+    process.env['ARIA_AI_API_KEY'] = 'override-key';
+    const fetchMock = mockClaudeJson('ok');
+    vi.stubGlobal('fetch', fetchMock);
+
+    const req = makeReq();
+    const res = makeRes();
+    await handler(req, res);
+
+    const headers = fetchMock.mock.calls[0][1].headers as Record<string, string>;
+    expect(headers['x-api-key']).toBe('override-key');
+  });
+
+  it('should return a valid Aria reply from Claude response', async () => {
+    const fetchMock = mockClaudeJson('I have been watching you.', 2);
+    vi.stubGlobal('fetch', fetchMock);
+
+    const req = makeReq();
+    const res = makeRes();
+    await handler(req, res);
+
+    expect(res._status).toBe(200);
+    expect((res._json as any).reply).toBe('I have been watching you.');
+    expect((res._json as any).trustDelta).toBe(2);
+  });
+
+  it('should return fallback when Claude response is non-ok', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValue({
+          ok: false,
+          status: 529,
+          text: vi.fn().mockResolvedValue('overloaded'),
+        }),
+    );
+
+    const req = makeReq();
+    const res = makeRes();
+    await handler(req, res);
+
+    expect(res._status).toBe(200);
+    expect((res._json as any).reply).toBe(FALLBACK);
+  });
+
+  it('should return fallback when Claude returns empty content', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue({ content: [] }),
+      }),
+    );
+
+    const req = makeReq();
+    const res = makeRes();
+    await handler(req, res);
+
+    expect(res._status).toBe(200);
+    expect((res._json as any).reply).toBe(FALLBACK);
   });
 });

--- a/api/__tests__/aria.test.ts
+++ b/api/__tests__/aria.test.ts
@@ -760,3 +760,28 @@ describe('POST /api/aria — Claude provider', () => {
     expect((res._json as any).reply).toBe(FALLBACK);
   });
 });
+
+describe('POST /api/aria — ARIA_AI_API_KEY universal override on Gemini path', () => {
+  it('should use ARIA_AI_API_KEY over GEMINI_API_KEY when model is Gemini', async () => {
+    process.env['ARIA_AI_API_KEY'] = 'universal-override-key';
+    process.env['GEMINI_API_KEY'] = 'original-gemini-key';
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        candidates: [{ content: { parts: [{ text: JSON.stringify({ reply: 'ok', trustDelta: 0 }) }] } }],
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const req = makeReq();
+    const res = makeRes();
+    await handler(req, res);
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toContain('universal-override-key');
+    expect(url).not.toContain('original-gemini-key');
+    expect(res._status).toBe(200);
+  });
+});

--- a/api/__tests__/aria.test.ts
+++ b/api/__tests__/aria.test.ts
@@ -684,6 +684,21 @@ describe('POST /api/aria — Claude provider', () => {
     expect(url).toContain('v1/messages');
   });
 
+  it('should default to https://api.anthropic.com when ARIA_AI_BASE_URL is unset', async () => {
+    delete process.env['ARIA_AI_BASE_URL'];
+    const fetchMock = mockClaudeJson('Still watching.');
+    vi.stubGlobal('fetch', fetchMock);
+
+    const req = makeReq();
+    const res = makeRes();
+    await handler(req, res);
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toContain('api.anthropic.com');
+    expect(url).not.toContain('generativelanguage.googleapis.com');
+  });
+
   it('should send x-api-key header with ANTHROPIC_API_KEY value', async () => {
     const fetchMock = mockClaudeJson('Noted.');
     vi.stubGlobal('fetch', fetchMock);

--- a/api/__tests__/aria.test.ts
+++ b/api/__tests__/aria.test.ts
@@ -726,13 +726,11 @@ describe('POST /api/aria — Claude provider', () => {
   it('should return fallback when Claude response is non-ok', async () => {
     vi.stubGlobal(
       'fetch',
-      vi
-        .fn()
-        .mockResolvedValue({
-          ok: false,
-          status: 529,
-          text: vi.fn().mockResolvedValue('overloaded'),
-        }),
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 529,
+        text: vi.fn().mockResolvedValue('overloaded'),
+      }),
     );
 
     const req = makeReq();
@@ -769,7 +767,9 @@ describe('POST /api/aria — ARIA_AI_API_KEY universal override on Gemini path',
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
       json: vi.fn().mockResolvedValue({
-        candidates: [{ content: { parts: [{ text: JSON.stringify({ reply: 'ok', trustDelta: 0 }) }] } }],
+        candidates: [
+          { content: { parts: [{ text: JSON.stringify({ reply: 'ok', trustDelta: 0 }) }] } },
+        ],
       }),
     });
     vi.stubGlobal('fetch', fetchMock);

--- a/api/aria.ts
+++ b/api/aria.ts
@@ -24,8 +24,8 @@ import { ValidationError, requireObject, requireString } from './_lib/validate.j
 
 const log = makeLogger('aria');
 
-const GEMINI_API_URL =
-  'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent';
+const GEMINI_DEFAULT_BASE_URL = 'https://generativelanguage.googleapis.com/v1beta/models';
+const GEMINI_DEFAULT_MODEL = 'gemini-2.5-flash';
 
 // Mirrors src/types/game.ts#FavorOffer — kept in sync manually (api/ cannot import from src/)
 type FavorOffer = { description: string; cost: number };
@@ -92,12 +92,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       return res.status(400).json({ error: err.message });
     }
     return res.status(400).json({ error: 'Invalid request body' });
-  }
-
-  const apiKey = process.env['GEMINI_API_KEY'];
-  if (!apiKey) {
-    log.error('GEMINI_API_KEY not set');
-    return res.status(200).json(FALLBACK_RESPONSE);
   }
 
   try {
@@ -180,42 +174,99 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       );
     }
 
-    const fullPrompt = [SYSTEM_PROMPT, contextParts.join('\n'), `Player: ${message}`, 'Aria:']
-      .filter(Boolean)
-      .join('\n\n');
-
-    const geminiRes = await fetch(`${GEMINI_API_URL}?key=${apiKey}`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        contents: [{ parts: [{ text: fullPrompt }] }],
-        generationConfig: {
-          maxOutputTokens: 300,
-          temperature: 0.9,
-          responseMimeType: 'application/json',
-        },
-        // Only relax DANGEROUS_CONTENT — the hacking fiction theme references
-        // security topics that can trigger this category at default thresholds.
-        // Harassment, hate speech, and sexually explicit filters remain at default.
-        safetySettings: [
-          { category: 'HARM_CATEGORY_DANGEROUS_CONTENT', threshold: 'BLOCK_ONLY_HIGH' },
-        ],
-      }),
-    });
-
-    if (!geminiRes.ok) {
-      const errBody = await geminiRes.text();
-      log.error('Gemini HTTP error', geminiRes.status, errBody);
+    // Read provider config at request time so env vars can be changed without redeploying
+    const ariaModel = process.env['ARIA_AI_MODEL'] ?? GEMINI_DEFAULT_MODEL;
+    const ariaBaseUrl = process.env['ARIA_AI_BASE_URL'] ?? GEMINI_DEFAULT_BASE_URL;
+    const isClaude = ariaModel.startsWith('claude-');
+    const apiKey =
+      process.env['ARIA_AI_API_KEY'] ??
+      (isClaude ? process.env['ANTHROPIC_API_KEY'] : process.env['GEMINI_API_KEY']);
+    if (!apiKey) {
+      const keyName = isClaude ? 'ANTHROPIC_API_KEY' : 'GEMINI_API_KEY';
+      log.error(`${keyName} not set (or ARIA_AI_API_KEY)`);
       return res.status(200).json(FALLBACK_RESPONSE);
     }
 
-    const data = (await geminiRes.json()) as {
-      candidates?: { content?: { parts?: { text?: string }[] } }[];
-    };
-    const text = data.candidates?.[0]?.content?.parts?.[0]?.text?.trim();
-    if (!text) {
-      log.error('Gemini empty response', JSON.stringify(data).slice(0, 500));
-      return res.status(200).json(FALLBACK_RESPONSE);
+    let text: string | undefined;
+
+    if (isClaude) {
+      const claudeUrl = `${ariaBaseUrl}/v1/messages`;
+      const claudeRes = await fetch(claudeUrl, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-api-key': apiKey,
+          'anthropic-version': '2023-06-01',
+        },
+        body: JSON.stringify({
+          model: ariaModel,
+          max_tokens: 300,
+          temperature: 0.9,
+          system: SYSTEM_PROMPT,
+          messages: [
+            {
+              role: 'user',
+              content: [contextParts.join('\n'), `Player: ${message}`, 'Aria:']
+                .filter(Boolean)
+                .join('\n\n'),
+            },
+          ],
+        }),
+      });
+
+      if (!claudeRes.ok) {
+        const errBody = await claudeRes.text();
+        log.error('Claude HTTP error', claudeRes.status, errBody);
+        return res.status(200).json(FALLBACK_RESPONSE);
+      }
+
+      const claudeData = (await claudeRes.json()) as {
+        content?: { type: string; text: string }[];
+      };
+      text = claudeData.content?.[0]?.text?.trim();
+      if (!text) {
+        log.error('Claude empty response', JSON.stringify(claudeData).slice(0, 500));
+        return res.status(200).json(FALLBACK_RESPONSE);
+      }
+    } else {
+      const fullPrompt = [SYSTEM_PROMPT, contextParts.join('\n'), `Player: ${message}`, 'Aria:']
+        .filter(Boolean)
+        .join('\n\n');
+
+      const geminiUrl = `${ariaBaseUrl}/${ariaModel}:generateContent`;
+      const geminiRes = await fetch(`${geminiUrl}?key=${apiKey}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          contents: [{ parts: [{ text: fullPrompt }] }],
+          generationConfig: {
+            maxOutputTokens: 300,
+            temperature: 0.9,
+            responseMimeType: 'application/json',
+          },
+          // Only relax DANGEROUS_CONTENT — the hacking fiction theme references
+          // security topics that can trigger this category at default thresholds.
+          // Harassment, hate speech, and sexually explicit filters remain at default.
+          safetySettings: [
+            { category: 'HARM_CATEGORY_DANGEROUS_CONTENT', threshold: 'BLOCK_ONLY_HIGH' },
+          ],
+        }),
+      });
+
+      if (!geminiRes.ok) {
+        const errBody = await geminiRes.text();
+        log.error('Gemini HTTP error', geminiRes.status, errBody);
+        return res.status(200).json(FALLBACK_RESPONSE);
+      }
+
+      const geminiData = (await geminiRes.json()) as {
+        candidates?: { content?: { parts?: { text?: string }[] } }[];
+      };
+      text = geminiData.candidates?.[0]?.content?.parts?.[0]?.text?.trim();
+      if (!text) {
+        log.error('Gemini empty response', JSON.stringify(geminiData).slice(0, 500));
+        return res.status(200).json(FALLBACK_RESPONSE);
+      }
     }
 
     const stripped = text
@@ -225,7 +276,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const jsonStart = stripped.indexOf('{');
     const jsonEnd = stripped.lastIndexOf('}');
     if (jsonStart === -1 || jsonEnd === -1 || jsonEnd <= jsonStart) {
-      log.error('No JSON object in Gemini response', stripped.slice(0, 200));
+      log.error('No JSON object in AI response', stripped.slice(0, 200));
       return res.status(200).json(FALLBACK_RESPONSE);
     }
     const parsed = JSON.parse(stripped.slice(jsonStart, jsonEnd + 1)) as Partial<AriaAIResponse>;

--- a/api/aria.ts
+++ b/api/aria.ts
@@ -1,6 +1,6 @@
 /**
  * POST /api/aria
- * Aria dialogue handler — proxies to Gemini with full context (§10.2 contract).
+ * Aria dialogue handler — proxies to Gemini Flash or Claude (configurable via env vars, §10.2 contract).
  *
  * Request body:
  *   {

--- a/api/aria.ts
+++ b/api/aria.ts
@@ -174,10 +174,12 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       );
     }
 
-    // Read provider config at request time so env vars can be changed without redeploying
+    // Read provider config at request time so it is configured via env vars rather than hardcoded
     const ariaModel = process.env['ARIA_AI_MODEL'] ?? GEMINI_DEFAULT_MODEL;
-    const ariaBaseUrl = process.env['ARIA_AI_BASE_URL'] ?? GEMINI_DEFAULT_BASE_URL;
     const isClaude = ariaModel.startsWith('claude-');
+    const ariaBaseUrl =
+      process.env['ARIA_AI_BASE_URL'] ??
+      (isClaude ? 'https://api.anthropic.com' : GEMINI_DEFAULT_BASE_URL);
     const apiKey =
       process.env['ARIA_AI_API_KEY'] ??
       (isClaude ? process.env['ANTHROPIC_API_KEY'] : process.env['GEMINI_API_KEY']);
@@ -221,9 +223,9 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       }
 
       const claudeData = (await claudeRes.json()) as {
-        content?: { type: string; text: string }[];
+        content?: { type: string; text?: string }[];
       };
-      text = claudeData.content?.[0]?.text?.trim();
+      text = claudeData.content?.find(b => b.type === 'text')?.text?.trim();
       if (!text) {
         log.error('Claude empty response', JSON.stringify(claudeData).slice(0, 500));
         return res.status(200).json(FALLBACK_RESPONSE);

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,7 +7,7 @@ import tseslint from 'typescript-eslint';
 import prettierConfig from 'eslint-config-prettier';
 
 export default tseslint.config(
-  { ignores: ['dist', 'coverage'] },
+  { ignores: ['dist', 'coverage', '.claude/worktrees/**'] },
   {
     extends: [js.configs.recommended, ...tseslint.configs.strictTypeChecked, prettierConfig],
     files: ['**/*.{ts,tsx}'],


### PR DESCRIPTION
Implements #issue-33

Adds `ARIA_AI_MODEL`, `ARIA_AI_BASE_URL`, and `ARIA_AI_API_KEY` env vars so the Aria dialogue provider can be switched from Gemini Flash to Claude Haiku via config alone — no code changes needed.

Generated with [Claude Code](https://claude.ai/code)