### PR TITLE
feat: view-cam command — AI-powered CCTV feed on ops_cctv_ctrl

### DIFF
--- a/api/__tests__/camera.test.ts
+++ b/api/__tests__/camera.test.ts
@@ -157,7 +157,7 @@ describe('POST /api/camera-feed — Gemini success', () => {
     const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
     const prompt: string = body.contents[0].parts[0].text;
     expect(prompt).toContain('cam_02');
-    expect(prompt).toContain('server_room');
+    expect(prompt).toContain('server room');
   });
 });
 

--- a/api/__tests__/camera.test.ts
+++ b/api/__tests__/camera.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import handler from '../camera-feed.js';
+
+function makeReq(overrides: Record<string, unknown> = {}) {
+  return {
+    method: 'POST',
+    body: { cameraId: 'cam_01', location: 'lobby' },
+    ...overrides,
+  } as any;
+}
+
+function makeRes() {
+  const res = {
+    _status: 200,
+    _json: undefined as unknown,
+    status(code: number) {
+      res._status = code;
+      return res;
+    },
+    json(data: unknown) {
+      res._json = data;
+      return res;
+    },
+  };
+  return res;
+}
+
+const FALLBACK = 'FEED DEGRADED — signal lost';
+
+beforeEach(() => {
+  delete process.env['GEMINI_API_KEY'];
+  delete process.env['ARIA_AI_API_KEY'];
+  vi.unstubAllGlobals();
+});
+
+afterEach(() => {
+  delete process.env['GEMINI_API_KEY'];
+  delete process.env['ARIA_AI_API_KEY'];
+  vi.unstubAllGlobals();
+});
+
+describe('POST /api/camera-feed — method guard', () => {
+  it('should return 405 for GET requests', async () => {
+    const req = makeReq({ method: 'GET' });
+    const res = makeRes();
+    await handler(req, res);
+    expect(res._status).toBe(405);
+    expect((res._json as any).error).toBe('Method not allowed');
+  });
+});
+
+describe('POST /api/camera-feed — validation', () => {
+  it('should return 400 when body is not an object', async () => {
+    const req = makeReq({ body: 'bad' });
+    const res = makeRes();
+    await handler(req, res);
+    expect(res._status).toBe(400);
+    expect((res._json as any).error).toContain('Request body');
+  });
+
+  it('should return 400 when cameraId is missing', async () => {
+    const req = makeReq({ body: { location: 'lobby' } });
+    const res = makeRes();
+    await handler(req, res);
+    expect(res._status).toBe(400);
+    expect((res._json as any).error).toContain('cameraId');
+  });
+
+  it('should return 400 when cameraId is empty', async () => {
+    const req = makeReq({ body: { cameraId: '', location: 'lobby' } });
+    const res = makeRes();
+    await handler(req, res);
+    expect(res._status).toBe(400);
+    expect((res._json as any).error).toContain('cameraId');
+  });
+
+  it('should return 400 when location is missing', async () => {
+    const req = makeReq({ body: { cameraId: 'cam_01' } });
+    const res = makeRes();
+    await handler(req, res);
+    expect(res._status).toBe(400);
+    expect((res._json as any).error).toContain('location');
+  });
+
+  it('should return 400 when location is empty', async () => {
+    const req = makeReq({ body: { cameraId: 'cam_01', location: '' } });
+    const res = makeRes();
+    await handler(req, res);
+    expect(res._status).toBe(400);
+    expect((res._json as any).error).toContain('location');
+  });
+});
+
+describe('POST /api/camera-feed — missing API key', () => {
+  it('should return fallback when GEMINI_API_KEY is not set', async () => {
+    const req = makeReq();
+    const res = makeRes();
+    await handler(req, res);
+    expect(res._status).toBe(200);
+    expect((res._json as any).description).toBe(FALLBACK);
+  });
+
+  it('should use ARIA_AI_API_KEY when GEMINI_API_KEY is absent', async () => {
+    process.env['ARIA_AI_API_KEY'] = 'override-key';
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        candidates: [{ content: { parts: [{ text: 'Two guards, north corridor.' }] } }],
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const req = makeReq();
+    const res = makeRes();
+    await handler(req, res);
+
+    expect(res._status).toBe(200);
+    expect((res._json as any).description).toBe('Two guards, north corridor.');
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toContain('override-key');
+  });
+});
+
+describe('POST /api/camera-feed — Gemini success', () => {
+  it('should return description from Gemini response', async () => {
+    process.env['GEMINI_API_KEY'] = 'test-key';
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        candidates: [{ content: { parts: [{ text: 'Empty lobby. Motion sensor inactive.' }] } }],
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const req = makeReq();
+    const res = makeRes();
+    await handler(req, res);
+
+    expect(res._status).toBe(200);
+    expect((res._json as any).description).toBe('Empty lobby. Motion sensor inactive.');
+  });
+
+  it('should pass cameraId and location in the prompt', async () => {
+    process.env['GEMINI_API_KEY'] = 'test-key';
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        candidates: [{ content: { parts: [{ text: 'Server racks humming.' }] } }],
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const req = makeReq({ body: { cameraId: 'cam_02', location: 'server_room' } });
+    const res = makeRes();
+    await handler(req, res);
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
+    const prompt: string = body.contents[0].parts[0].text;
+    expect(prompt).toContain('cam_02');
+    expect(prompt).toContain('server_room');
+  });
+});
+
+describe('POST /api/camera-feed — Gemini errors', () => {
+  it('should return fallback on non-ok Gemini response', async () => {
+    process.env['GEMINI_API_KEY'] = 'test-key';
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 503,
+        text: vi.fn().mockResolvedValue('service unavailable'),
+      }),
+    );
+
+    const req = makeReq();
+    const res = makeRes();
+    await handler(req, res);
+
+    expect(res._status).toBe(200);
+    expect((res._json as any).description).toBe(FALLBACK);
+  });
+
+  it('should return fallback when Gemini returns empty candidates', async () => {
+    process.env['GEMINI_API_KEY'] = 'test-key';
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue({ candidates: [] }),
+      }),
+    );
+
+    const req = makeReq();
+    const res = makeRes();
+    await handler(req, res);
+
+    expect(res._status).toBe(200);
+    expect((res._json as any).description).toBe(FALLBACK);
+  });
+
+  it('should return fallback when fetch throws', async () => {
+    process.env['GEMINI_API_KEY'] = 'test-key';
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network error')));
+
+    const req = makeReq();
+    const res = makeRes();
+    await handler(req, res);
+
+    expect(res._status).toBe(200);
+    expect((res._json as any).description).toBe(FALLBACK);
+  });
+});

--- a/api/camera-feed.ts
+++ b/api/camera-feed.ts
@@ -67,6 +67,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       body: JSON.stringify({
         contents: [{ parts: [{ text: prompt }] }],
         generationConfig: { maxOutputTokens: 500, temperature: 0.85 },
+        thinkingConfig: { thinkingBudget: 0 },
       }),
     });
 

--- a/api/camera-feed.ts
+++ b/api/camera-feed.ts
@@ -1,0 +1,93 @@
+/**
+ * POST /api/camera-feed
+ * Proxies to Gemini (CCTV camera description generation).
+ *
+ * Request body:
+ *   { cameraId: string, location: string }
+ *
+ * Response:
+ *   200 { description: string }
+ *   400 { error: string }          — malformed payload
+ *   200 { description: string }    — fallback when Gemini is unavailable
+ */
+
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { makeLogger } from './_lib/logger.js';
+import { ValidationError, requireObject, requireString } from './_lib/validate.js';
+
+export interface CameraFeedRequest {
+  cameraId: string;
+  location: string;
+}
+
+export interface CameraFeedResponse {
+  description: string;
+}
+
+const log = makeLogger('camera-feed');
+
+const GEMINI_API_URL =
+  'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent';
+const FALLBACK_DESCRIPTION = 'FEED DEGRADED — signal lost';
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  let cameraId: string;
+  let location: string;
+  try {
+    const body = requireObject(req.body, 'Request body');
+    cameraId = requireString(body['cameraId'], 'cameraId');
+    location = requireString(body['location'], 'location');
+  } catch (err) {
+    if (err instanceof ValidationError) {
+      return res.status(400).json({ error: err.message });
+    }
+    return res.status(400).json({ error: 'Invalid request body' });
+  }
+
+  const apiKey = process.env['ARIA_AI_API_KEY'] ?? process.env['GEMINI_API_KEY'];
+  if (!apiKey) {
+    log.error('GEMINI_API_KEY not set (or ARIA_AI_API_KEY)');
+    return res.status(200).json({ description: FALLBACK_DESCRIPTION });
+  }
+
+  try {
+    const prompt =
+      `You are a security camera feed display system inside IronGate Corp, a powerful and secretive corporation. ` +
+      `Generate a terse, clinical surveillance description of what camera ${cameraId} (location: ${location}) currently shows. ` +
+      `Write in present tense. Two to four sentences. Describe people, activity, lighting, and any anomalies. ` +
+      `Tone: cold, factual, sci-fi noir. No markdown. No camera ID prefix.`;
+
+    const geminiRes = await fetch(`${GEMINI_API_URL}?key=${apiKey}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        contents: [{ parts: [{ text: prompt }] }],
+        generationConfig: { maxOutputTokens: 150, temperature: 0.85 },
+      }),
+    });
+
+    if (!geminiRes.ok) {
+      const errBody = await geminiRes.text();
+      log.error('Gemini HTTP error', geminiRes.status, errBody);
+      return res.status(200).json({ description: FALLBACK_DESCRIPTION });
+    }
+
+    const data = (await geminiRes.json()) as {
+      candidates?: { content?: { parts?: { text?: string }[] } }[];
+    };
+    const text = data.candidates?.[0]?.content?.parts?.[0]?.text?.trim();
+    if (!text) {
+      log.error('Gemini empty response', JSON.stringify(data).slice(0, 500));
+      return res.status(200).json({ description: FALLBACK_DESCRIPTION });
+    }
+
+    return res.status(200).json({ description: text });
+  } catch (e) {
+    log.error('Unexpected error', e);
+    return res.status(200).json({ description: FALLBACK_DESCRIPTION });
+  }
+}

--- a/api/camera-feed.ts
+++ b/api/camera-feed.ts
@@ -57,16 +57,16 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   try {
     const prompt =
       `You are a security camera feed display system inside IronGate Corp, a powerful and secretive corporation. ` +
-      `Generate a terse, clinical surveillance description of what camera ${cameraId} (location: ${location}) currently shows. ` +
-      `Write in present tense. Two to four sentences. Describe people, activity, lighting, and any anomalies. ` +
-      `Tone: cold, factual, sci-fi noir. No markdown. No camera ID prefix.`;
+      `Generate a terse, clinical surveillance description of what camera ${cameraId} (location: ${location.replace('_', ' ')}) currently shows. ` +
+      `Write in present tense. Exactly two to three complete sentences. Describe people, activity, lighting, and any anomalies. ` +
+      `Tone: cold, factual, sci-fi noir. No markdown. No prefix of any kind — begin directly with the description.`;
 
     const geminiRes = await fetch(`${GEMINI_API_URL}?key=${apiKey}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         contents: [{ parts: [{ text: prompt }] }],
-        generationConfig: { maxOutputTokens: 300, temperature: 0.85 },
+        generationConfig: { maxOutputTokens: 500, temperature: 0.85 },
       }),
     });
 

--- a/api/camera-feed.ts
+++ b/api/camera-feed.ts
@@ -48,16 +48,22 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return res.status(400).json({ error: 'Invalid request body' });
   }
 
-  const apiKey = process.env['ARIA_AI_API_KEY'] ?? process.env['GEMINI_API_KEY'];
+  const apiKey = process.env['GEMINI_API_KEY'] ?? process.env['ARIA_AI_API_KEY'];
   if (!apiKey) {
     log.error('GEMINI_API_KEY not set (or ARIA_AI_API_KEY)');
     return res.status(200).json({ description: FALLBACK_DESCRIPTION });
   }
 
   try {
+    const safeCameraId = cameraId.slice(0, 16).replace(/[^\w]/g, '');
+    const safeLocation = location
+      .slice(0, 64)
+      .replace(/[^\w ]/g, '')
+      .replaceAll('_', ' ');
+
     const prompt =
       `You are a security camera feed display system inside IronGate Corp, a powerful and secretive corporation. ` +
-      `Generate a terse, clinical surveillance description of what camera ${cameraId} (location: ${location.replace('_', ' ')}) currently shows. ` +
+      `Generate a terse, clinical surveillance description of what camera ${safeCameraId} (location: ${safeLocation}) currently shows. ` +
       `Write in present tense. Exactly two to three complete sentences. Describe people, activity, lighting, and any anomalies. ` +
       `Tone: cold, factual, sci-fi noir. No markdown. No prefix of any kind — begin directly with the description.`;
 
@@ -66,8 +72,11 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         contents: [{ parts: [{ text: prompt }] }],
-        generationConfig: { maxOutputTokens: 500, temperature: 0.85 },
-        thinkingConfig: { thinkingBudget: 0 },
+        generationConfig: {
+          maxOutputTokens: 500,
+          temperature: 0.85,
+          thinkingConfig: { thinkingBudget: 0 },
+        },
       }),
     });
 

--- a/api/camera-feed.ts
+++ b/api/camera-feed.ts
@@ -66,7 +66,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         contents: [{ parts: [{ text: prompt }] }],
-        generationConfig: { maxOutputTokens: 150, temperature: 0.85 },
+        generationConfig: { maxOutputTokens: 300, temperature: 0.85 },
       }),
     });
 

--- a/docs/superpowers/plans/2026-04-18-view-cam.md
+++ b/docs/superpowers/plans/2026-04-18-view-cam.md
@@ -1,0 +1,779 @@
+# view-cam Command Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `view-cam <id>` command on `ops_cctv_ctrl` that returns an AI-generated Gemini surveillance description; cam_03 costs +1% trace.
+
+**Architecture:** A new Vercel endpoint `/api/camera-feed.ts` (mirrors `/api/file.ts`) accepts `{ cameraId, location }` and returns `{ description }`. A new `cmdViewCam` async function in `commands.ts` gates on node + access, applies trace for cam_03 before the fetch, and formats output as `aria`-typed lines. The `view-cam` case is added to the engine commands switch and the HelpModal is updated.
+
+**Tech Stack:** TypeScript, Vitest, MSW (mock service worker), Vercel serverless functions, Google Gemini API.
+
+---
+
+## File Map
+
+| Action | Path | Responsibility |
+|---|---|---|
+| Create | `api/camera-feed.ts` | Gemini endpoint — validate body, call API, return `{ description }` |
+| Create | `api/__tests__/camera.test.ts` | Unit tests for the endpoint |
+| Modify | `src/engine/commands.ts` | Add `cmdViewCam` function + `case 'view-cam'` in engine switch |
+| Modify | `src/mocks/handlers.ts` | Add MSW handler for `POST /api/camera-feed` |
+| Modify | `src/components/HelpModal.tsx` | Add `view-cam` entry under ENGINE COMMANDS |
+| Modify | `src/engine/commands.test.ts` | Integration smoke tests for `view-cam` via `resolveCommand` |
+
+---
+
+## Task 1: MSW handler for `/api/camera-feed`
+
+**Files:**
+- Modify: `src/mocks/handlers.ts`
+
+- [ ] **Step 1: Add handler**
+
+Open `src/mocks/handlers.ts` and add the camera-feed handler at the end of the `handlers` array:
+
+```typescript
+http.post('/api/camera-feed', () => {
+  return HttpResponse.json({ description: '[MOCK CAMERA FEED]' });
+}),
+```
+
+Full file after edit:
+
+```typescript
+import { http, HttpResponse } from 'msw';
+
+export const handlers = [
+  http.post('/api/world', () => {
+    return HttpResponse.json({
+      narrative: '[MOCK WORLD RESPONSE]',
+      traceChange: 0,
+      accessGranted: false,
+      newAccessLevel: null,
+      flagsSet: {},
+      nodesUnlocked: [],
+      isUnknown: false,
+    });
+  }),
+
+  http.post('/api/file', () => {
+    return HttpResponse.json({ content: '[MOCK FILE CONTENT]' });
+  }),
+
+  http.post('/api/node-description', () => {
+    return HttpResponse.json({ description: '[MOCK NODE DESCRIPTION]' });
+  }),
+
+  http.post('/api/aria', () => {
+    return HttpResponse.json({ reply: '[ARIA: signal received]', trustDelta: 2 });
+  }),
+
+  http.post('/api/camera-feed', () => {
+    return HttpResponse.json({ description: '[MOCK CAMERA FEED]' });
+  }),
+];
+```
+
+- [ ] **Step 2: Verify existing tests still pass**
+
+```bash
+npm run test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/mocks/handlers.ts
+git commit -m "test(mocks): add MSW handler for /api/camera-feed"
+```
+
+---
+
+## Task 2: `/api/camera-feed.ts` endpoint — failing tests first
+
+**Files:**
+- Create: `api/__tests__/camera.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `api/__tests__/camera.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import handler from '../camera-feed.js';
+
+function makeReq(overrides: Record<string, unknown> = {}) {
+  return {
+    method: 'POST',
+    body: { cameraId: 'cam_01', location: 'lobby' },
+    ...overrides,
+  } as any;
+}
+
+function makeRes() {
+  const res = {
+    _status: 200,
+    _json: undefined as unknown,
+    status(code: number) {
+      res._status = code;
+      return res;
+    },
+    json(data: unknown) {
+      res._json = data;
+      return res;
+    },
+  };
+  return res;
+}
+
+const FALLBACK = 'FEED DEGRADED — signal lost';
+
+beforeEach(() => {
+  delete process.env['GEMINI_API_KEY'];
+  delete process.env['ARIA_AI_API_KEY'];
+  vi.unstubAllGlobals();
+});
+
+afterEach(() => {
+  delete process.env['GEMINI_API_KEY'];
+  delete process.env['ARIA_AI_API_KEY'];
+  vi.unstubAllGlobals();
+});
+
+describe('POST /api/camera-feed — method guard', () => {
+  it('should return 405 for GET requests', async () => {
+    const req = makeReq({ method: 'GET' });
+    const res = makeRes();
+    await handler(req, res);
+    expect(res._status).toBe(405);
+    expect((res._json as any).error).toBe('Method not allowed');
+  });
+});
+
+describe('POST /api/camera-feed — validation', () => {
+  it('should return 400 when body is not an object', async () => {
+    const req = makeReq({ body: 'bad' });
+    const res = makeRes();
+    await handler(req, res);
+    expect(res._status).toBe(400);
+    expect((res._json as any).error).toContain('Request body');
+  });
+
+  it('should return 400 when cameraId is missing', async () => {
+    const req = makeReq({ body: { location: 'lobby' } });
+    const res = makeRes();
+    await handler(req, res);
+    expect(res._status).toBe(400);
+    expect((res._json as any).error).toContain('cameraId');
+  });
+
+  it('should return 400 when cameraId is empty', async () => {
+    const req = makeReq({ body: { cameraId: '', location: 'lobby' } });
+    const res = makeRes();
+    await handler(req, res);
+    expect(res._status).toBe(400);
+    expect((res._json as any).error).toContain('cameraId');
+  });
+
+  it('should return 400 when location is missing', async () => {
+    const req = makeReq({ body: { cameraId: 'cam_01' } });
+    const res = makeRes();
+    await handler(req, res);
+    expect(res._status).toBe(400);
+    expect((res._json as any).error).toContain('location');
+  });
+
+  it('should return 400 when location is empty', async () => {
+    const req = makeReq({ body: { cameraId: 'cam_01', location: '' } });
+    const res = makeRes();
+    await handler(req, res);
+    expect(res._status).toBe(400);
+    expect((res._json as any).error).toContain('location');
+  });
+});
+
+describe('POST /api/camera-feed — missing API key', () => {
+  it('should return fallback when GEMINI_API_KEY is not set', async () => {
+    const req = makeReq();
+    const res = makeRes();
+    await handler(req, res);
+    expect(res._status).toBe(200);
+    expect((res._json as any).description).toBe(FALLBACK);
+  });
+
+  it('should use ARIA_AI_API_KEY when GEMINI_API_KEY is absent', async () => {
+    process.env['ARIA_AI_API_KEY'] = 'override-key';
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        candidates: [{ content: { parts: [{ text: 'Two guards, north corridor.' }] } }],
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const req = makeReq();
+    const res = makeRes();
+    await handler(req, res);
+
+    expect(res._status).toBe(200);
+    expect((res._json as any).description).toBe('Two guards, north corridor.');
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toContain('override-key');
+  });
+});
+
+describe('POST /api/camera-feed — Gemini success', () => {
+  it('should return description from Gemini response', async () => {
+    process.env['GEMINI_API_KEY'] = 'test-key';
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        candidates: [{ content: { parts: [{ text: 'Empty lobby. Motion sensor inactive.' }] } }],
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const req = makeReq();
+    const res = makeRes();
+    await handler(req, res);
+
+    expect(res._status).toBe(200);
+    expect((res._json as any).description).toBe('Empty lobby. Motion sensor inactive.');
+  });
+
+  it('should pass cameraId and location in the prompt', async () => {
+    process.env['GEMINI_API_KEY'] = 'test-key';
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        candidates: [{ content: { parts: [{ text: 'Server racks humming.' }] } }],
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const req = makeReq({ body: { cameraId: 'cam_02', location: 'server_room' } });
+    const res = makeRes();
+    await handler(req, res);
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
+    const prompt: string = body.contents[0].parts[0].text;
+    expect(prompt).toContain('cam_02');
+    expect(prompt).toContain('server_room');
+  });
+});
+
+describe('POST /api/camera-feed — Gemini errors', () => {
+  it('should return fallback on non-ok Gemini response', async () => {
+    process.env['GEMINI_API_KEY'] = 'test-key';
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 503,
+        text: vi.fn().mockResolvedValue('service unavailable'),
+      }),
+    );
+
+    const req = makeReq();
+    const res = makeRes();
+    await handler(req, res);
+
+    expect(res._status).toBe(200);
+    expect((res._json as any).description).toBe(FALLBACK);
+  });
+
+  it('should return fallback when Gemini returns empty candidates', async () => {
+    process.env['GEMINI_API_KEY'] = 'test-key';
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue({ candidates: [] }),
+      }),
+    );
+
+    const req = makeReq();
+    const res = makeRes();
+    await handler(req, res);
+
+    expect(res._status).toBe(200);
+    expect((res._json as any).description).toBe(FALLBACK);
+  });
+
+  it('should return fallback when fetch throws', async () => {
+    process.env['GEMINI_API_KEY'] = 'test-key';
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network error')));
+
+    const req = makeReq();
+    const res = makeRes();
+    await handler(req, res);
+
+    expect(res._status).toBe(200);
+    expect((res._json as any).description).toBe(FALLBACK);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+npm run test -- api/__tests__/camera.test.ts
+```
+
+Expected: FAIL — `../camera-feed.js` not found.
+
+---
+
+## Task 3: Implement `/api/camera-feed.ts`
+
+**Files:**
+- Create: `api/camera-feed.ts`
+
+- [ ] **Step 1: Create the endpoint**
+
+```typescript
+/**
+ * POST /api/camera-feed
+ * Proxies to Gemini (CCTV camera description generation).
+ *
+ * Request body:
+ *   { cameraId: string, location: string }
+ *
+ * Response:
+ *   200 { description: string }
+ *   400 { error: string }          — malformed payload
+ *   200 { description: string }    — fallback when Gemini is unavailable
+ */
+
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { makeLogger } from './_lib/logger.js';
+import { ValidationError, requireObject, requireString } from './_lib/validate.js';
+
+export interface CameraFeedRequest {
+  cameraId: string;
+  location: string;
+}
+
+export interface CameraFeedResponse {
+  description: string;
+}
+
+const log = makeLogger('camera-feed');
+
+const GEMINI_API_URL =
+  'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent';
+const FALLBACK_DESCRIPTION = 'FEED DEGRADED — signal lost';
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  let cameraId: string;
+  let location: string;
+  try {
+    const body = requireObject(req.body, 'Request body');
+    cameraId = requireString(body['cameraId'], 'cameraId');
+    location = requireString(body['location'], 'location');
+  } catch (err) {
+    if (err instanceof ValidationError) {
+      return res.status(400).json({ error: err.message });
+    }
+    return res.status(400).json({ error: 'Invalid request body' });
+  }
+
+  const apiKey = process.env['ARIA_AI_API_KEY'] ?? process.env['GEMINI_API_KEY'];
+  if (!apiKey) {
+    log.error('GEMINI_API_KEY not set (or ARIA_AI_API_KEY)');
+    return res.status(200).json({ description: FALLBACK_DESCRIPTION });
+  }
+
+  try {
+    const prompt =
+      `You are a security camera feed display system inside IronGate Corp, a powerful and secretive corporation. ` +
+      `Generate a terse, clinical surveillance description of what camera ${cameraId} (location: ${location}) currently shows. ` +
+      `Write in present tense. Two to four sentences. Describe people, activity, lighting, and any anomalies. ` +
+      `Tone: cold, factual, sci-fi noir. No markdown. No camera ID prefix.`;
+
+    const geminiRes = await fetch(`${GEMINI_API_URL}?key=${apiKey}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        contents: [{ parts: [{ text: prompt }] }],
+        generationConfig: { maxOutputTokens: 150, temperature: 0.85 },
+      }),
+    });
+
+    if (!geminiRes.ok) {
+      const errBody = await geminiRes.text();
+      log.error('Gemini HTTP error', geminiRes.status, errBody);
+      return res.status(200).json({ description: FALLBACK_DESCRIPTION });
+    }
+
+    const data = (await geminiRes.json()) as {
+      candidates?: { content?: { parts?: { text?: string }[] } }[];
+    };
+    const text = data.candidates?.[0]?.content?.parts?.[0]?.text?.trim();
+    if (!text) {
+      log.error('Gemini empty response', JSON.stringify(data).slice(0, 500));
+      return res.status(200).json({ description: FALLBACK_DESCRIPTION });
+    }
+
+    return res.status(200).json({ description: text });
+  } catch (e) {
+    log.error('Unexpected error', e);
+    return res.status(200).json({ description: FALLBACK_DESCRIPTION });
+  }
+}
+```
+
+- [ ] **Step 2: Run tests to confirm they pass**
+
+```bash
+npm run test -- api/__tests__/camera.test.ts
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 3: Build and lint check**
+
+```bash
+npm run build && npm run lint
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add api/camera-feed.ts api/__tests__/camera.test.ts
+git commit -m "feat(api): add /api/camera-feed Gemini endpoint"
+```
+
+---
+
+## Task 4: `cmdViewCam` function in `commands.ts`
+
+**Files:**
+- Modify: `src/engine/commands.ts`
+
+The camera map is fixed to the three cameras in `ops_cctv_ctrl`'s `camera_config.ini`.
+
+- [ ] **Step 1: Write failing integration tests first**
+
+Open `src/engine/commands.test.ts` and add a new describe block at the end of the file:
+
+```typescript
+describe('view-cam command', () => {
+  const cctvState = (): GameState => {
+    const s = createInitialState();
+    // Connect to ops_cctv_ctrl with user access
+    return produce(s, draft => {
+      draft.network.currentNodeId = 'ops_cctv_ctrl';
+      draft.network.nodes['ops_cctv_ctrl'].accessLevel = 'user';
+    });
+  };
+
+  it('should return error when not on ops_cctv_ctrl', async () => {
+    const s = createInitialState(); // default node is contractor_portal, not ops_cctv_ctrl
+    const result = await resolveCommand('view-cam cam_01', s);
+    expect(result.lines.some(l => l.type === 'error')).toBe(true);
+  });
+
+  it('should return error when access is none', async () => {
+    const s = produce(createInitialState(), draft => {
+      draft.network.currentNodeId = 'ops_cctv_ctrl';
+      draft.network.nodes['ops_cctv_ctrl'].accessLevel = 'none';
+    });
+    const result = await resolveCommand('view-cam cam_01', s);
+    expect(result.lines.some(l => l.type === 'error')).toBe(true);
+  });
+
+  it('should return error for unknown camera ID', async () => {
+    const s = cctvState();
+    const result = await resolveCommand('view-cam cam_99', s);
+    expect(result.lines.some(l => l.type === 'error')).toBe(true);
+  });
+
+  it('should return aria-typed lines for cam_01 with no trace change', async () => {
+    const s = cctvState();
+    const result = await resolveCommand('view-cam cam_01', s);
+    expect(result.lines.some(l => l.type === 'aria')).toBe(true);
+    const traceBefore = s.player.trace;
+    const traceAfter = (result.nextState as GameState | undefined)?.player.trace ?? traceBefore;
+    expect(traceAfter).toBe(traceBefore);
+  });
+
+  it('should return aria-typed lines for cam_02 with no trace change', async () => {
+    const s = cctvState();
+    const result = await resolveCommand('view-cam cam_02', s);
+    expect(result.lines.some(l => l.type === 'aria')).toBe(true);
+    const traceBefore = s.player.trace;
+    const traceAfter = (result.nextState as GameState | undefined)?.player.trace ?? traceBefore;
+    expect(traceAfter).toBe(traceBefore);
+  });
+
+  it('should apply +1 trace for cam_03 regardless of feed outcome', async () => {
+    const s = cctvState();
+    const traceBefore = s.player.trace;
+    const result = await resolveCommand('view-cam cam_03', s);
+    const traceAfter = (result.nextState as GameState).player.trace;
+    expect(traceAfter).toBe(traceBefore + 1);
+  });
+
+  it('should render fallback line gracefully when API returns fallback text', async () => {
+    const s = cctvState();
+    // MSW handler returns '[MOCK CAMERA FEED]' — the command should render it as aria line
+    const result = await resolveCommand('view-cam cam_02', s);
+    expect(result.lines.some(l => l.type === 'aria')).toBe(true);
+  });
+
+  it('should show usage hint when no camera ID provided', async () => {
+    const s = cctvState();
+    const result = await resolveCommand('view-cam', s);
+    expect(result.lines.some(l => l.type === 'error')).toBe(true);
+  });
+});
+```
+
+Note: `createInitialState`, `produce`, `resolveCommand`, and `GameState` are already imported in `commands.test.ts`. No new imports are needed.
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+npm run test -- src/engine/commands.test.ts --reporter=verbose 2>&1 | grep "view-cam"
+```
+
+Expected: FAIL — `view-cam` not handled, falls through to World AI mock.
+
+- [ ] **Step 3: Add the `CAMERA_MAP` constant and `cmdViewCam` function to `commands.ts`**
+
+Add the following immediately before the final `};` closing line of the file (after the last existing command function):
+
+```typescript
+// ── view-cam ─────────────────────────────────────────────
+const CAMERA_MAP: Record<string, { location: string; traceCost: number }> = {
+  cam_01: { location: 'lobby', traceCost: 0 },
+  cam_02: { location: 'server_room', traceCost: 0 },
+  cam_03: { location: 'executive_floor', traceCost: 1 },
+};
+
+const CAMERA_FEED_FALLBACK = 'FEED DEGRADED — signal lost';
+
+const cmdViewCam = async (args: string[], state: GameState): Promise<CommandOutput> => {
+  if (!args[0]) return { lines: [err('Usage: view-cam [cam_01|cam_02|cam_03]')] };
+
+  const node = currentNode(state);
+  if (node.id !== 'ops_cctv_ctrl') {
+    return { lines: [err('No camera feed available from this node.')] };
+  }
+  if (node.accessLevel === 'none') {
+    return { lines: [err('Permission denied — not authenticated')] };
+  }
+
+  const cam = CAMERA_MAP[args[0]];
+  if (!cam) {
+    return { lines: [err(`Unknown camera: ${args[0]}. Known cameras: cam_01, cam_02, cam_03`)] };
+  }
+
+  // Apply trace before fetch — registers even on network failure
+  let nextState: GameState | undefined;
+  if (cam.traceCost > 0) {
+    nextState = addTrace(state, cam.traceCost, `view-cam:${args[0]}`);
+  }
+
+  let description = CAMERA_FEED_FALLBACK;
+  try {
+    const res = await fetch('/api/camera-feed', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ cameraId: args[0], location: cam.location }),
+    });
+    if (res.ok) {
+      const data = (await res.json()) as { description?: string };
+      if (typeof data.description === 'string' && data.description.length > 0) {
+        description = data.description;
+      }
+    }
+  } catch {
+    // fallback already set
+  }
+
+  const lines: Out = [
+    sep(),
+    line(`// CCTV — ${args[0].toUpperCase()} — ${cam.location.replace('_', ' ').toUpperCase()}`, 'aria'),
+    ...description.split('\n').map(l => line(l, 'aria')),
+    sep(),
+  ];
+
+  if (cam.traceCost > 0) {
+    lines.push(line(`  +${String(cam.traceCost)} trace (restricted feed accessed)`, 'system'));
+  }
+
+  return { lines, nextState };
+};
+```
+
+- [ ] **Step 4: Add `case 'view-cam'` to the engine commands switch**
+
+In `commands.ts`, find the engine commands `switch (verb)` block (around line 256). Add after the `case 'wipe-logs':` block but before the closing `}` of the switch:
+
+```typescript
+    case 'view-cam':
+      return withTurn(await cmdViewCam(args, state), raw, state);
+```
+
+The switch block should look like:
+
+```typescript
+  switch (verb) {
+    case 'scan':
+      result = cmdScan(args, state);
+      break;
+    case 'connect':
+      return withTurn(await cmdConnect(args, state), raw, state);
+    case 'login':
+      result = cmdLogin(args, state);
+      break;
+    case 'ls':
+      result = cmdLs(args, state);
+      break;
+    case 'cat':
+      return withTurn(await cmdCat(args, state), raw, state);
+    case 'disconnect':
+    case 'exit':
+    case 'logoff':
+    case 'logout':
+      result = cmdDisconnect(state);
+      break;
+    case 'exploit':
+      return withTurn(await cmdExploit(args, state), raw, state);
+    case 'exfil':
+      result = cmdExfil(args, state);
+      break;
+    case 'decrypt':
+      result = cmdDecrypt(args, state);
+      break;
+    case 'wipe-logs':
+      result = cmdWipeLogs(state);
+      break;
+    case 'spoof':
+      result = cmdSpoof(state);
+      break;
+    case 'unlock': {
+      const unlockResult = cmdUnlock(args, state);
+      if (unlockResult.hardened) return { lines: unlockResult.lines };
+      return withTurn(unlockResult, raw, state);
+    }
+    case 'view-cam':
+      return withTurn(await cmdViewCam(args, state), raw, state);
+  }
+```
+
+- [ ] **Step 5: Run tests to confirm they pass**
+
+```bash
+npm run test -- src/engine/commands.test.ts --reporter=verbose 2>&1 | grep -A1 "view-cam"
+```
+
+Expected: all `view-cam` tests PASS.
+
+- [ ] **Step 6: Full test suite + build + lint**
+
+```bash
+npm run test && npm run build && npm run lint
+```
+
+Expected: all pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/engine/commands.ts src/engine/commands.test.ts
+git commit -m "feat(engine): add view-cam command with Gemini camera feed"
+```
+
+---
+
+## Task 5: Update HelpModal
+
+**Files:**
+- Modify: `src/components/HelpModal.tsx`
+
+- [ ] **Step 1: Add `view-cam` entry to the ENGINE COMMANDS section**
+
+In `src/components/HelpModal.tsx`, find the `spoof` entry (last engine command):
+
+```typescript
+  {
+    text: r('  spoof               -trace -20 (requires spoof-id)'),
+    color: 'var(--color-system)',
+  },
+```
+
+Add immediately after it:
+
+```typescript
+  {
+    text: r('  view-cam [id]       -view CCTV feed (cam_03: +1 trace)'),
+    color: 'var(--color-system)',
+  },
+```
+
+- [ ] **Step 2: Build to confirm no TypeScript errors**
+
+```bash
+npm run build
+```
+
+Expected: builds cleanly.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/HelpModal.tsx
+git commit -m "feat(ui): add view-cam to help modal"
+```
+
+---
+
+## Task 6: Coverage check and final validation
+
+- [ ] **Step 1: Run coverage**
+
+```bash
+npm run test:coverage
+```
+
+Expected: all files at or above 75% threshold. If `api/camera-feed.ts` or the new `cmdViewCam` code is below threshold, add tests to `api/__tests__/camera.test.ts` or `src/engine/commands.test.ts` to cover the missing branches.
+
+- [ ] **Step 2: Run knip**
+
+```bash
+npm run knip
+```
+
+Expected: no unused exports reported for the new files.
+
+- [ ] **Step 3: Format**
+
+```bash
+npm run format
+```
+
+- [ ] **Step 4: Final build + lint**
+
+```bash
+npm run build && npm run lint
+```
+
+Expected: clean.
+
+- [ ] **Step 5: Commit if any format changes**
+
+```bash
+git add -p
+git commit -m "chore: format after view-cam implementation"
+```

--- a/docs/superpowers/specs/2026-04-18-view-cam-design.md
+++ b/docs/superpowers/specs/2026-04-18-view-cam-design.md
@@ -1,0 +1,82 @@
+# view-cam Command — Design Spec
+
+**Date:** 2026-04-18
+**Status:** Approved
+
+## Summary
+
+Add a `view-cam <id>` command that lets the player read AI-generated surveillance descriptions from the CCTV controller node (`ops_cctv_ctrl`). Read-only, zero trace cost for cam_01 and cam_02. cam_03 (disabled by CEO office) triggers +1% trace as a risk/reward mechanic.
+
+## Architecture
+
+Three layers of new code:
+
+### 1. `/api/camera-feed.ts` — Vercel serverless endpoint
+
+- **Method:** POST
+- **Request body:** `{ cameraId: string, location: string, nodeContext?: string }`
+- **Response:** `{ description: string }`
+- **AI provider:** Gemini (same pattern as `/api/file.ts`) — `GEMINI_API_KEY` required, `ARIA_AI_API_KEY` as universal override
+- **System prompt:** establishes IronGate Corp surveillance tone — terse, clinical, sci-fi noir; describes what the camera sees at this moment (people, activity, lighting, anomalies)
+- **Fallback:** static `"FEED DEGRADED — signal lost"` on Gemini error or missing key; always returns HTTP 200
+
+### 2. `src/engine/cmdViewCam.ts` — engine command
+
+- Gate: player must be connected to `ops_cctv_ctrl` with at least `user` access; otherwise return an error line
+- Camera list derived from `camera_config.ini` content already on the node: `cam_01=lobby`, `cam_02=server_room`, `cam_03=executive_floor`
+- Unknown camera ID → error line, no state change
+- cam_03: apply `+1` trace to `nextState` **before** the fetch (trace registers even on network failure)
+- cam_01, cam_02: zero trace cost, no state change
+- Response lines typed as `aria` for visual distinction in the terminal
+- No turn counter increment (zero-cost like `ls`)
+
+### 3. `src/engine/commands.ts`
+
+- Add `case 'view-cam'` to the engine command switch, delegating to `cmdViewCam`
+
+## Data Flow
+
+```
+player: view-cam 02
+  → resolveCommand: verb=view-cam, args=['02']
+  → cmdViewCam: on ops_cctv_ctrl? user access? known cam?
+  → cam_03? nextState = apply trace +1
+  → POST /api/camera-feed { cameraId: 'cam_02', location: 'server_room' }
+  → Gemini returns surveillance description
+  → lines (aria type) + nextState returned to App.tsx
+```
+
+## Error Handling
+
+| Scenario | Behaviour |
+|---|---|
+| Wrong node | Error line: "No camera feed available from this node." |
+| Insufficient access | Error line: "Access denied." |
+| Unknown camera ID | Error line: "Unknown camera: <id>." |
+| Gemini unavailable / key missing | Fallback line: "FEED DEGRADED — signal lost" |
+| cam_03 (any outcome) | Trace +1 applied regardless of feed success |
+
+## Testing
+
+### `api/__tests__/camera.test.ts`
+- Valid request returns `{ description }` from Gemini
+- Missing required fields return 400
+- Missing `GEMINI_API_KEY` returns fallback description
+- Gemini HTTP error returns fallback description
+
+### `src/engine/cmdViewCam.test.ts`
+- Wrong node returns error, no state change
+- Insufficient access returns error
+- Unknown camera ID returns error
+- cam_01 / cam_02: no trace added, lines typed `aria`
+- cam_03: trace +1 in nextState before fetch; trace registered even on Gemini failure
+- Gemini fallback renders gracefully as `aria` line
+
+### `src/mocks/handlers.ts`
+- Add MSW handler for `POST /api/camera-feed` returning a static description
+
+## Out of Scope
+
+- Camera control (pan, tilt, disable) — read-only only
+- Caching / per-run seed consistency — freshly generated each view
+- Extending `view-cam` to other nodes

--- a/src/components/HelpModal.tsx
+++ b/src/components/HelpModal.tsx
@@ -72,7 +72,7 @@ const BODY: HelpLine[] = [
     color: 'var(--color-system)',
   },
   {
-    text: r('  view-cam [id]       -view CCTV feed (cam_03: +1 trace)'),
+    text: r('  view-cam [id]       view CCTV feed (cam_03: +1 trace)'),
     color: 'var(--color-system)',
   },
   { text: r(), color: 'var(--color-system)' },

--- a/src/components/HelpModal.tsx
+++ b/src/components/HelpModal.tsx
@@ -71,6 +71,10 @@ const BODY: HelpLine[] = [
     text: r('  spoof               -trace -20 (requires spoof-id)'),
     color: 'var(--color-system)',
   },
+  {
+    text: r('  view-cam [id]       -view CCTV feed (cam_03: +1 trace)'),
+    color: 'var(--color-system)',
+  },
   { text: r(), color: 'var(--color-system)' },
   { text: r('MESSAGING:'), color: 'var(--color-output)' },
   {

--- a/src/engine/commands.test.ts
+++ b/src/engine/commands.test.ts
@@ -3658,3 +3658,72 @@ describe('unlock command', () => {
     expect(s5.unlockAttempts[filePath]).toBeUndefined();
   });
 });
+
+describe('view-cam command', () => {
+  const cctvState = (): GameState => {
+    const s = createInitialState();
+    return produce(s, draft => {
+      draft.network.currentNodeId = 'ops_cctv_ctrl';
+      draft.network.nodes['ops_cctv_ctrl']!.accessLevel = 'user';
+    });
+  };
+
+  it('should return error when not on ops_cctv_ctrl', async () => {
+    const s = createInitialState();
+    const result = await resolveCommand('view-cam cam_01', s);
+    expect(result.lines.some(l => l.type === 'error')).toBe(true);
+  });
+
+  it('should return error when access is none', async () => {
+    const s = produce(createInitialState(), draft => {
+      draft.network.currentNodeId = 'ops_cctv_ctrl';
+      draft.network.nodes['ops_cctv_ctrl']!.accessLevel = 'none';
+    });
+    const result = await resolveCommand('view-cam cam_01', s);
+    expect(result.lines.some(l => l.type === 'error')).toBe(true);
+  });
+
+  it('should return error for unknown camera ID', async () => {
+    const s = cctvState();
+    const result = await resolveCommand('view-cam cam_99', s);
+    expect(result.lines.some(l => l.type === 'error')).toBe(true);
+  });
+
+  it('should return aria-typed lines for cam_01 with no trace change', async () => {
+    const s = cctvState();
+    const result = await resolveCommand('view-cam cam_01', s);
+    expect(result.lines.some(l => l.type === 'aria')).toBe(true);
+    const traceBefore = s.player.trace;
+    const traceAfter = (result.nextState as GameState | undefined)?.player.trace ?? traceBefore;
+    expect(traceAfter).toBe(traceBefore);
+  });
+
+  it('should return aria-typed lines for cam_02 with no trace change', async () => {
+    const s = cctvState();
+    const result = await resolveCommand('view-cam cam_02', s);
+    expect(result.lines.some(l => l.type === 'aria')).toBe(true);
+    const traceBefore = s.player.trace;
+    const traceAfter = (result.nextState as GameState | undefined)?.player.trace ?? traceBefore;
+    expect(traceAfter).toBe(traceBefore);
+  });
+
+  it('should apply +1 trace for cam_03 regardless of feed outcome', async () => {
+    const s = cctvState();
+    const traceBefore = s.player.trace;
+    const result = await resolveCommand('view-cam cam_03', s);
+    const traceAfter = (result.nextState as GameState).player.trace;
+    expect(traceAfter).toBe(traceBefore + 1);
+  });
+
+  it('should render fallback line gracefully when API returns fallback text', async () => {
+    const s = cctvState();
+    const result = await resolveCommand('view-cam cam_02', s);
+    expect(result.lines.some(l => l.type === 'aria')).toBe(true);
+  });
+
+  it('should show usage hint when no camera ID provided', async () => {
+    const s = cctvState();
+    const result = await resolveCommand('view-cam', s);
+    expect(result.lines.some(l => l.type === 'error')).toBe(true);
+  });
+});

--- a/src/engine/commands.ts
+++ b/src/engine/commands.ts
@@ -294,6 +294,8 @@ export const resolveCommand = async (raw: string, state: GameState): Promise<Com
       if (unlockResult.hardened) return { lines: unlockResult.lines };
       return withTurn(unlockResult, raw, state);
     }
+    case 'view-cam':
+      return withTurn(await cmdViewCam(args, state), raw, state);
   }
   if (result) return withTurn(result, raw, state);
 
@@ -1923,4 +1925,69 @@ const cmdUnlock = (args: string[], state: GameState): UnlockResult => {
     ],
     nextState: next,
   };
+};
+
+// ── view-cam ─────────────────────────────────────────────
+const CAMERA_MAP: Record<string, { location: string; traceCost: number } | undefined> = {
+  cam_01: { location: 'lobby', traceCost: 0 },
+  cam_02: { location: 'server_room', traceCost: 0 },
+  cam_03: { location: 'executive_floor', traceCost: 1 },
+};
+
+const CAMERA_FEED_FALLBACK = 'FEED DEGRADED — signal lost';
+
+const cmdViewCam = async (args: string[], state: GameState): Promise<CommandOutput> => {
+  if (!args[0]) return { lines: [err('Usage: view-cam [cam_01|cam_02|cam_03]')] };
+
+  const node = currentNode(state);
+  if (node.id !== 'ops_cctv_ctrl') {
+    return { lines: [err('No camera feed available from this node.')] };
+  }
+  if (node.accessLevel === 'none') {
+    return { lines: [err('Permission denied — not authenticated')] };
+  }
+
+  const cam = CAMERA_MAP[args[0]];
+  if (!cam) {
+    return { lines: [err(`Unknown camera: ${args[0]}. Known cameras: cam_01, cam_02, cam_03`)] };
+  }
+
+  // Apply trace before fetch — registers even on network failure
+  let nextState: GameState | undefined;
+  if (cam.traceCost > 0) {
+    nextState = addTrace(state, cam.traceCost, `view-cam:${args[0]}`);
+  }
+
+  let description = CAMERA_FEED_FALLBACK;
+  try {
+    const res = await fetch('/api/camera-feed', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ cameraId: args[0], location: cam.location }),
+    });
+    if (res.ok) {
+      const data = (await res.json()) as { description?: string };
+      if (typeof data.description === 'string' && data.description.length > 0) {
+        description = data.description;
+      }
+    }
+  } catch {
+    // fallback already set
+  }
+
+  const lines: Out = [
+    sep(),
+    line(
+      `// CCTV — ${args[0].toUpperCase()} — ${cam.location.replace('_', ' ').toUpperCase()}`,
+      'aria',
+    ),
+    ...description.split('\n').map(l => line(l, 'aria')),
+    sep(),
+  ];
+
+  if (cam.traceCost > 0) {
+    lines.push(line(`  +${String(cam.traceCost)} trace (restricted feed accessed)`, 'system'));
+  }
+
+  return { lines, nextState };
 };

--- a/src/engine/commands.ts
+++ b/src/engine/commands.ts
@@ -1978,7 +1978,7 @@ const cmdViewCam = async (args: string[], state: GameState): Promise<CommandOutp
   const lines: Out = [
     sep(),
     line(
-      `// CCTV — ${args[0].toUpperCase()} — ${cam.location.replace('_', ' ').toUpperCase()}`,
+      `// CCTV — ${args[0].toUpperCase()} — ${cam.location.replaceAll('_', ' ').toUpperCase()}`,
       'aria',
     ),
     ...description.split('\n').map(l => line(l, 'aria')),

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -24,4 +24,8 @@ export const handlers = [
   http.post('/api/aria', () => {
     return HttpResponse.json({ reply: '[ARIA: signal received]', trustDelta: 2 });
   }),
+
+  http.post('/api/camera-feed', () => {
+    return HttpResponse.json({ description: '[MOCK CAMERA FEED]' });
+  }),
 ];


### PR DESCRIPTION
## Summary

- Adds `view-cam <id>` command available on `ops_cctv_ctrl` with user-level access
- Calls new `/api/camera-feed` Gemini endpoint to generate terse, sci-fi noir surveillance descriptions
- `cam_01` (lobby) and `cam_02` (server room) are zero-cost; `cam_03` (executive floor, disabled) costs +1% trace
- Output rendered as `aria`-typed terminal lines

## Test Plan

- [ ] Connect to `ops_cctv_ctrl`, authenticate, run `view-cam cam_01` and `view-cam cam_02` — expect AI-generated descriptions
- [ ] Run `view-cam cam_03` — expect +1% trace applied and description returned
- [ ] Run `view-cam` on a non-CCTV node — expect error
- [ ] Run `view-cam cam_99` — expect unknown camera error
- [ ] Check `help` modal lists `view-cam [id]` under ENGINE COMMANDS

🤖 Generated with [Claude Code](https://claude.com/claude-code)